### PR TITLE
Return nullptr instead of throwing from EventStack pop/top

### DIFF
--- a/src/span.cpp
+++ b/src/span.cpp
@@ -71,8 +71,12 @@ namespace pinpoint {
     void SpanData::finishSpanEvent() {
         std::unique_lock<std::mutex> lock(span_event_lock_);
         const auto se = event_stack_.pop();
-        se->finish();
-        finished_events.push_back(se);
+        if (se) {
+            se->finish();
+            finished_events.push_back(se);
+        } else {
+            LOG_WARN("finishSpanEvent: abnormal span - has no event");
+        }
     }
 
     void SpanData::parseTraceId(std::string &txid) noexcept {
@@ -234,7 +238,12 @@ namespace pinpoint {
         CHECK_FINISHED_WITH_RETURN(noopSpanEvent());
         CHECK_OVERFLOW_WITH_RETURN(noopSpanEvent());
 
-        return data_->topSpanEvent();
+        auto se = data_->topSpanEvent();
+        if (!se) {
+            LOG_WARN("GetSpanEvent: abnormal span - has no event");
+            return noopSpanEvent();
+        }
+        return se;
     }
 
     void SpanImpl::record_chunk(bool final) const try {
@@ -357,6 +366,10 @@ namespace pinpoint {
         CHECK_OVERFLOW_WITH_RETURN(noopSpan());
 
         auto se = data_->topSpanEvent();
+        if (!se) {
+            LOG_WARN("NewAsyncSpan: abnormal span - has no event");
+            return noopSpan();
+        }
         auto async_span = std::make_shared<SpanImpl>(agent_, "", "");
 
         async_span->data_->setTraceId(data_->getTraceId());

--- a/src/span.h
+++ b/src/span.h
@@ -19,7 +19,6 @@
 #include <atomic>
 #include <mutex>
 #include <stack>
-#include <stdexcept>
 #include <vector>
 
 #include "agent_service.h"
@@ -61,13 +60,12 @@ namespace pinpoint {
         /**
          * @brief Removes and returns the most recent span event.
          *
-         * @return Span event that was at the top of the stack.
-         * @throws std::runtime_error if the stack is empty.
+         * @return Span event that was at the top of the stack, or nullptr if the stack is empty.
          * @note Caller must hold span_event_lock_.
          */
         std::shared_ptr<SpanEventImpl> pop() {
             if (stack_.empty()) {
-                throw std::runtime_error("Cannot pop from empty EventStack");
+                return nullptr;
             }
             auto item = stack_.top();
             stack_.pop();
@@ -76,12 +74,12 @@ namespace pinpoint {
 
         /**
          * @brief Returns (without removing) the top span event.
-         * @throws std::runtime_error if the stack is empty.
+         * @return Span event at the top of the stack, or nullptr if the stack is empty.
          * @note Caller must hold span_event_lock_.
          */
         std::shared_ptr<SpanEventImpl> top() {
             if (stack_.empty()) {
-                throw std::runtime_error("Cannot get top from empty EventStack");
+                return nullptr;
             }
             return stack_.top();
         }
@@ -268,7 +266,7 @@ namespace pinpoint {
     	 * @brief Finalizes the top span event and moves it into the finished list.
     	 */
     	void finishSpanEvent();
-    	/// @brief Returns the current active span event.
+    	/// @brief Returns the current active span event, or nullptr if the stack is empty.
     	std::shared_ptr<SpanEventImpl> topSpanEvent() {
     	    std::unique_lock<std::mutex> lock(span_event_lock_);
     	    return event_stack_.top();

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -303,21 +303,31 @@ TEST_F(SpanTest, EventStackConcurrentAccessTest) {
     EventStack stack;
     std::mutex stack_mutex;  // External mutex (mirrors SpanData::span_event_lock_)
 
-    const int num_threads = 4;
-    const int events_per_thread = 10;
+    constexpr int num_push_threads = 2;
+    constexpr int num_pop_threads = 2;
+    constexpr int events_per_thread = 10;
     std::atomic<int> push_count(0);
     std::atomic<int> pop_count(0);
+
+    // Pre-create all events on the main thread to avoid data races on
+    // MockAgentService (cacheApi / cached_apis_ is not thread-safe).
+    std::vector<std::vector<std::shared_ptr<SpanEventImpl>>> pre_created(num_push_threads);
+    for (int t = 0; t < num_push_threads; t++) {
+        for (int i = 0; i < events_per_thread; i++) {
+            pre_created[t].push_back(
+                std::make_shared<SpanEventImpl>(span_data.get(), "event" + std::to_string(t * events_per_thread + i)));
+        }
+    }
 
     std::vector<std::thread> threads;
 
     // Push threads
-    for (int t = 0; t < num_threads / 2; t++) {
-        threads.emplace_back([&stack, &stack_mutex, &span_data, &push_count]() {
+    for (int t = 0; t < num_push_threads; t++) {
+        threads.emplace_back([&stack, &stack_mutex, &push_count, &events = pre_created[t]]() {
             for (int i = 0; i < events_per_thread; i++) {
-                auto event = std::make_shared<SpanEventImpl>(span_data.get(), "event" + std::to_string(i));
                 {
                     std::lock_guard<std::mutex> lock(stack_mutex);
-                    stack.push(event);
+                    stack.push(events[i]);
                 }
                 push_count++;
                 std::this_thread::sleep_for(std::chrono::microseconds(1));
@@ -329,9 +339,10 @@ TEST_F(SpanTest, EventStackConcurrentAccessTest) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     // Pop threads
-    for (int t = 0; t < num_threads / 2; t++) {
+    constexpr int total_to_pop = events_per_thread;  // pop half the total pushed
+    for (int t = 0; t < num_pop_threads; t++) {
         threads.emplace_back([&stack, &stack_mutex, &pop_count]() {
-            while (pop_count < 10) {  // Try to pop some events
+            while (pop_count < total_to_pop) {
                 {
                     std::lock_guard<std::mutex> lock(stack_mutex);
                     if (stack.size() > 0) {
@@ -349,10 +360,11 @@ TEST_F(SpanTest, EventStackConcurrentAccessTest) {
         thread.join();
     }
 
-    // Drain remaining events before span_data is destroyed
+    // Drain remaining events so they are destroyed while span_data is alive
     while (stack.size() > 0) {
         stack.pop();
     }
+    pre_created.clear();
 
     EXPECT_GT(push_count.load(), 0) << "Should have pushed some events";
     EXPECT_GT(pop_count.load(), 0) << "Should have popped some events";

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -299,9 +299,9 @@ TEST_F(SpanTest, EventStackBasicOperationsTest) {
 }
 
 TEST_F(SpanTest, EventStackConcurrentAccessTest) {
+    auto span_data = std::make_shared<SpanData>(mock_agent_service_.get(), "test-operation");
     EventStack stack;
     std::mutex stack_mutex;  // External mutex (mirrors SpanData::span_event_lock_)
-    auto span_data = std::make_shared<SpanData>(mock_agent_service_.get(), "test-operation");
 
     const int num_threads = 4;
     const int events_per_thread = 10;
@@ -332,14 +332,12 @@ TEST_F(SpanTest, EventStackConcurrentAccessTest) {
     for (int t = 0; t < num_threads / 2; t++) {
         threads.emplace_back([&stack, &stack_mutex, &pop_count]() {
             while (pop_count < 10) {  // Try to pop some events
-                try {
+                {
                     std::lock_guard<std::mutex> lock(stack_mutex);
                     if (stack.size() > 0) {
                         stack.pop();
                         pop_count++;
                     }
-                } catch (...) {
-                    break; // Stack might be empty
                 }
                 std::this_thread::sleep_for(std::chrono::microseconds(1));
             }
@@ -349,6 +347,11 @@ TEST_F(SpanTest, EventStackConcurrentAccessTest) {
     // Wait for all threads to complete
     for (auto& thread : threads) {
         thread.join();
+    }
+
+    // Drain remaining events before span_data is destroyed
+    while (stack.size() > 0) {
+        stack.pop();
     }
 
     EXPECT_GT(push_count.load(), 0) << "Should have pushed some events";


### PR DESCRIPTION
## Changes

- Modified `EventStack::pop()` and `EventStack::top()` to return `nullptr` instead of throwing `std::runtime_error` when the stack is empty
- Updated all callers in `SpanData::finishSpanEvent()`, `SpanImpl::GetSpanEvent()`, and `SpanImpl::NewAsyncSpan()` to handle `nullptr` returns with appropriate null checks and warning logs
- Removed `#include <stdexcept>` as it's no longer needed
- Fixed data race in `EventStackConcurrentAccessTest` by pre-creating all `SpanEventImpl` objects on the main thread before spawning worker threads, avoiding concurrent access to `MockAgentService`
- Updated test to use separate push and pop thread counts and removed exception handling in favor of checking stack size before popping
- Ensured proper cleanup of test resources