### PR TITLE
Decouple gRPC clients from AgentService via constructor injection

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -38,8 +38,14 @@ namespace pinpoint {
         std::mutex global_agent_mutex;
     }
 
-    AgentImpl::AgentImpl(std::shared_ptr<const Config> cfg) :
+    AgentImpl::AgentImpl(std::shared_ptr<const Config> cfg,
+                         std::unique_ptr<GrpcAgent> grpc_agent,
+                         std::unique_ptr<GrpcSpan> grpc_span,
+                         std::unique_ptr<GrpcStats> grpc_stat) :
         config_(std::move(cfg)),
+        grpc_agent_(std::move(grpc_agent)),
+        grpc_span_(std::move(grpc_span)),
+        grpc_stat_(std::move(grpc_stat)),
         start_time_(to_milli_seconds(std::chrono::system_clock::now())),
         trace_id_sequence_(1) {
 
@@ -170,9 +176,9 @@ namespace pinpoint {
     }
 
     void AgentImpl::init_grpc_workers() try {
-        grpc_agent_ = std::make_unique<GrpcAgent>(this);
-        grpc_span_ = std::make_unique<GrpcSpan>(this);
-        grpc_stat_ = std::make_unique<GrpcStats>(this);
+        grpc_agent_->setAgentService(this);
+        grpc_span_->setAgentService(this);
+        grpc_stat_->setAgentService(this);
 
         do {
             if (!grpc_agent_->readyChannel()) {
@@ -516,7 +522,11 @@ namespace pinpoint {
             return nullptr;
         }
         try {
-            return std::make_shared<AgentImpl>(cfg);
+            auto grpc_agent = std::make_unique<GrpcAgent>(cfg);
+            auto grpc_span = std::make_unique<GrpcSpan>(cfg);
+            auto grpc_stat = std::make_unique<GrpcStats>(cfg);
+            return std::make_shared<AgentImpl>(cfg,
+                std::move(grpc_agent), std::move(grpc_span), std::move(grpc_stat));
         } catch (const std::exception& e) {
             LOG_ERROR("make agent exception = {}", e.what());
             return nullptr;

--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -57,7 +57,7 @@ namespace pinpoint {
         sql_cache_ = std::make_unique<IdCache>(kCacheSize);
         sql_uid_cache_ = std::make_unique<SqlUidCache>(kCacheSize);
         
-        reloadConfig(cfg);
+        reloadConfig(config_);
 
         init_thread_ = std::thread{&AgentImpl::init_grpc_workers, this};
         start_config_file_watcher();

--- a/src/agent.h
+++ b/src/agent.h
@@ -46,7 +46,10 @@ namespace pinpoint {
 		 *
 		 * @param options Resolved agent configuration.
 		 */
-		explicit AgentImpl(std::shared_ptr<const Config> options);
+		AgentImpl(std::shared_ptr<const Config> options,
+				  std::unique_ptr<GrpcAgent> grpc_agent,
+				  std::unique_ptr<GrpcSpan> grpc_span,
+				  std::unique_ptr<GrpcStats> grpc_stat);
         ~AgentImpl() override;
 
 		/**

--- a/src/grpc.cpp
+++ b/src/grpc.cpp
@@ -35,37 +35,6 @@ namespace pinpoint {
         constexpr int MAX_MESSAGE_LENGTH = 4 * 1024 * 1024; // 4 MB
     }
 
-    static void build_grpc_context(grpc::ClientContext* context, const AgentService* agent, int socket_id) {
-        const auto config = agent->getConfig();
-
-        context->AddMetadata("applicationname", config->app_name_);
-        context->AddMetadata("agentid", config->agent_id_);
-        context->AddMetadata("starttime", std::to_string(agent->getStartTime()));
-
-        if (!config->agent_name_.empty()) {
-            context->AddMetadata("agentname", config->agent_name_);
-        }
-        if (socket_id > 0) {
-            context->AddMetadata("socketid", std::to_string(socket_id));
-        }
-    }
-
-    static void build_agent_info(const AgentService* agent, v1::PAgentInfo* agent_info, google::protobuf::Arena* arena) {
-        const auto config = agent->getConfig();
-        agent_info->set_hostname(get_host_name());
-        agent_info->set_ip(get_host_ip_addr());
-        agent_info->set_servicetype(config->app_type_);
-        agent_info->set_pid(getpid());
-        agent_info->set_agentversion(VERSION_STRING);
-        agent_info->set_container(config->is_container);
-
-        const auto meta_data = google::protobuf::Arena::Create<v1::PServerMetaData>(arena);
-        meta_data->set_serverinfo("C/C++");
-        meta_data->add_vmarg(to_config_string(*config));
-
-        agent_info->set_allocated_servermetadata(meta_data);
-    }
-
     static v1::PTransactionId* build_transaction_id(TraceId& tid, google::protobuf::Arena* arena) {
         auto& [agent_id, start_time, sequence] = tid;
         auto* ptid = google::protobuf::Arena::Create<v1::PTransactionId>(arena);
@@ -397,18 +366,18 @@ namespace pinpoint {
         return uri_stat;
     }
 
-    GrpcClient::GrpcClient(AgentService* agent, ClientType client_type) : agent_{agent} {
-        const auto config = agent_->getConfig();
-        auto addr = absl::StrCat(config->collector.host, ":");
+    GrpcClient::GrpcClient(ClientType client_type, std::shared_ptr<const Config> config)
+        : config_{std::move(config)} {
+        auto addr = absl::StrCat(config_->collector.host, ":");
 
         if (client_type == AGENT) {
-            addr = absl::StrCat(addr, config->collector.agent_port);
+            addr = absl::StrCat(addr, config_->collector.agent_port);
             client_name_ = "agent";
         } else if (client_type == SPAN) {
-            addr = absl::StrCat(addr, config->collector.span_port);
+            addr = absl::StrCat(addr, config_->collector.span_port);
             client_name_ = "span";
         } else {
-            addr = absl::StrCat(addr, config->collector.stat_port);
+            addr = absl::StrCat(addr, config_->collector.stat_port);
             client_name_ = "stats";
         }
 
@@ -419,6 +388,23 @@ namespace pinpoint {
         channel_args.SetInt(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH, MAX_MESSAGE_LENGTH);
 
         channel_ = grpc::CreateCustomChannel(addr, grpc::InsecureChannelCredentials(), channel_args);
+    }
+
+    void GrpcClient::setAgentService(AgentService* agent) {
+        agent_ = agent;
+    }
+
+    void GrpcClient::build_grpc_context(grpc::ClientContext* context, int socket_id) const {
+        context->AddMetadata("applicationname", config_->app_name_);
+        context->AddMetadata("agentid", config_->agent_id_);
+        context->AddMetadata("starttime", std::to_string(agent_->getStartTime()));
+
+        if (!config_->agent_name_.empty()) {
+            context->AddMetadata("agentname", config_->agent_name_);
+        }
+        if (socket_id > 0) {
+            context->AddMetadata("socketid", std::to_string(socket_id));
+        }
     }
 
     bool GrpcClient::wait_channel_ready() const {
@@ -466,7 +452,7 @@ namespace pinpoint {
 
     //GrpcAgent
 
-    GrpcAgent::GrpcAgent(AgentService* agent) : GrpcClient(agent, AGENT) {
+    GrpcAgent::GrpcAgent(std::shared_ptr<const Config> config) : GrpcClient(AGENT, std::move(config)) {
         set_agent_stub(v1::Agent::NewStub(channel_));
         set_meta_stub(v1::Metadata::NewStub(channel_));
     }
@@ -479,16 +465,31 @@ namespace pinpoint {
         ctx.set_deadline(deadline);
     }
 
+    void GrpcAgent::build_agent_info(v1::PAgentInfo* agent_info, google::protobuf::Arena* arena) const {
+        agent_info->set_hostname(get_host_name());
+        agent_info->set_ip(get_host_ip_addr());
+        agent_info->set_servicetype(config_->app_type_);
+        agent_info->set_pid(getpid());
+        agent_info->set_agentversion(VERSION_STRING);
+        agent_info->set_container(config_->is_container);
+
+        const auto meta_data = google::protobuf::Arena::Create<v1::PServerMetaData>(arena);
+        meta_data->set_serverinfo("C/C++");
+        meta_data->add_vmarg(to_config_string(*config_));
+
+        agent_info->set_allocated_servermetadata(meta_data);
+    }
+
     GrpcRequestStatus GrpcAgent::registerAgent() {
         grpc::ClientContext ctx;
         v1::PResult reply;
 
         std::unique_lock<std::mutex> lock(channel_mutex_);
-        build_grpc_context(&ctx, agent_, 0);
+        build_grpc_context(&ctx, 0);
 
         google::protobuf::Arena arena;
         auto* agent_info = google::protobuf::Arena::Create<v1::PAgentInfo>(&arena);
-        build_agent_info(agent_, agent_info, &arena);
+        build_agent_info(agent_info, &arena);
 
         set_deadline(ctx, REGISTER_TIMEOUT);
         const grpc::Status status = agent_stub_->RequestAgentInfo(&ctx, *agent_info, &reply);
@@ -508,7 +509,7 @@ namespace pinpoint {
         grpc::ClientContext ctx;
         std::unique_lock<std::mutex> lock(channel_mutex_);
 
-        build_grpc_context(&ctx, agent_, 0);
+        build_grpc_context(&ctx, 0);
         set_deadline(ctx, META_TIMEOUT);
         
         const grpc::Status status = stub_method(&ctx, request, &reply);
@@ -619,7 +620,7 @@ namespace pinpoint {
     void GrpcAgent::enqueueMeta(std::unique_ptr<MetaData> meta) noexcept try {
         std::unique_lock<std::mutex> lock(meta_queue_mutex_);
 
-        const auto config = agent_->getConfig();
+        const auto& config = config_;
         if (meta_queue_.size() < config->span.queue_size) {
             meta_queue_.push(std::move(meta));
         } else {
@@ -693,7 +694,7 @@ namespace pinpoint {
         }
 
         stream_context_ = std::make_unique<grpc::ClientContext>();
-        build_grpc_context(stream_context_.get(), agent_, ++socket_id_);
+        build_grpc_context(stream_context_.get(), ++socket_id_);
         agent_stub_->async()->PingSession(stream_context_.get(), this);
 
         AddHold();
@@ -798,7 +799,7 @@ namespace pinpoint {
 
     //GrpcSpan
 
-    GrpcSpan::GrpcSpan(AgentService* agent) : GrpcClient(agent, SPAN) {
+    GrpcSpan::GrpcSpan(std::shared_ptr<const Config> config) : GrpcClient(SPAN, std::move(config)) {
         set_span_stub(v1::Span::NewStub(channel_));
     }
 
@@ -809,7 +810,7 @@ namespace pinpoint {
         }
 
         stream_context_ = std::make_unique<grpc::ClientContext>();
-        build_grpc_context(stream_context_.get(), agent_, 0);
+        build_grpc_context(stream_context_.get(), 0);
         span_stub_->async()->SendSpan(stream_context_.get(), &reply_, this);
 
         AddHold();
@@ -914,7 +915,7 @@ namespace pinpoint {
     void GrpcSpan::enqueueSpan(std::unique_ptr<SpanChunk> span) noexcept try {
         std::unique_lock<std::mutex> lock(span_queue_mutex_);
 
-        const auto config = agent_->getConfig();
+        const auto& config = config_;
         if (span_queue_.size() < config->span.queue_size) {
             span_queue_.push(std::move(span));
         } else {
@@ -982,7 +983,7 @@ namespace pinpoint {
 
     //GrpcStat
 
-    GrpcStats::GrpcStats(AgentService* agent): GrpcClient(agent, STATS) {
+    GrpcStats::GrpcStats(std::shared_ptr<const Config> config) : GrpcClient(STATS, std::move(config)) {
         set_stats_stub(v1::Stat::NewStub(channel_));
     }
 
@@ -993,7 +994,7 @@ namespace pinpoint {
         }
 
         stream_context_ = std::make_unique<grpc::ClientContext>();
-        build_grpc_context(stream_context_.get(), agent_, 0);
+        build_grpc_context(stream_context_.get(), 0);
         stats_stub_->async()->SendAgentStat(stream_context_.get(), &reply_, this);
 
         AddHold();
@@ -1097,7 +1098,7 @@ namespace pinpoint {
     constexpr size_t MAX_STATS_QUEUE_SIZE = 2;
 
     void GrpcStats::enqueueStats(const StatsType stats) noexcept try {
-        const auto config = agent_->getConfig();
+        const auto& config = config_;
         if (!config->stat.enable && !config->http.url_stat.enable) {
             return;
         }
@@ -1134,7 +1135,7 @@ namespace pinpoint {
     }
 
     void GrpcStats::sendStatsWorker() try {
-        const auto config = agent_->getConfig();
+        const auto& config = config_;
         if (!config->stat.enable && !config->http.url_stat.enable) {
             return;
         }
@@ -1173,7 +1174,7 @@ namespace pinpoint {
     }
 
     void GrpcStats::stopStatsWorker() {
-        const auto config = agent_->getConfig();
+        const auto& config = config_;
         if (!config->stat.enable && !config->http.url_stat.enable) {
             return;
         }

--- a/src/grpc.h
+++ b/src/grpc.h
@@ -72,7 +72,7 @@ namespace pinpoint {
          *
          * @return `true` if the channel is ready or successfully re-initialized.
          */
-        bool readyChannel();
+        virtual bool readyChannel();
         /// @brief Releases the current channel handle.
         void closeChannel() { channel_.reset(); }
 
@@ -202,7 +202,7 @@ namespace pinpoint {
         /**
          * @brief Registers the agent with the collector and starts ping streaming.
          */
-        GrpcRequestStatus registerAgent();
+        virtual GrpcRequestStatus registerAgent();
         /**
          * @brief Adds metadata to the outbound queue.
          *

--- a/src/grpc.h
+++ b/src/grpc.h
@@ -55,12 +55,18 @@ namespace pinpoint {
     class GrpcClient {
     public:
         /**
-         * @brief Constructs a client bound to an `AgentService` and client type.
+         * @brief Constructs a client for the given client type.
          *
-         * @param agent Owning agent service.
          * @param client_type Which collector service this client targets.
          */
-        explicit GrpcClient(AgentService* agent, ClientType client_type);
+        GrpcClient(ClientType client_type, std::shared_ptr<const Config> config);
+        /**
+         * @brief Injects the agent service.
+         *
+         * @param agent Owning agent service.
+         */
+        void setAgentService(AgentService* agent);
+        virtual ~GrpcClient() = default;
         /**
          * @brief Ensures the gRPC channel is connected and ready for use.
          *
@@ -72,6 +78,7 @@ namespace pinpoint {
 
     protected:
         AgentService* agent_{};
+        std::shared_ptr<const Config> config_{};
         std::shared_ptr<grpc::Channel> channel_{};
         std::mutex channel_mutex_{};
         std::string client_name_{};
@@ -87,6 +94,8 @@ namespace pinpoint {
          * @brief Blocks until the channel becomes ready or the deadline is exceeded.
          */
         bool wait_channel_ready() const;
+
+        void build_grpc_context(grpc::ClientContext* context, int socket_id) const;
     };
 
     /**
@@ -188,7 +197,7 @@ namespace pinpoint {
      */
     class GrpcAgent : public GrpcClient, public grpc::ClientBidiReactor<v1::PPing, v1::PPing> {
     public:
-        explicit GrpcAgent(AgentService* agent);
+        explicit GrpcAgent(std::shared_ptr<const Config> config);
 
         /**
          * @brief Registers the agent with the collector and starts ping streaming.
@@ -246,6 +255,7 @@ namespace pinpoint {
         GrpcRequestStatus send_sql_meta(StringMeta& sql_meta);
         GrpcRequestStatus send_sql_uid_meta(SqlUidMeta& sql_uid_meta);
         GrpcRequestStatus send_exception_meta(ExceptionMeta& exception_meta);
+        void build_agent_info(v1::PAgentInfo* agent_info, google::protobuf::Arena* arena) const;
     };
 
     /**
@@ -253,7 +263,7 @@ namespace pinpoint {
      */
     class GrpcSpan : public GrpcClient, public grpc::ClientWriteReactor<v1::PSpanMessage> {
     public:
-        explicit GrpcSpan(AgentService* agent);
+        explicit GrpcSpan(std::shared_ptr<const Config> config);
         ~GrpcSpan() override { arena_.Reset(); }        
 
         /**
@@ -299,7 +309,7 @@ namespace pinpoint {
      */
     class GrpcStats : public GrpcClient, public grpc::ClientWriteReactor<v1::PStatMessage> {
     public:
-        explicit GrpcStats(AgentService* agent);
+        explicit GrpcStats(std::shared_ptr<const Config> config);
         ~GrpcStats() override { arena_.Reset(); }
 
         /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -180,6 +180,15 @@ target_link_libraries(test_grpc_with_mocks
 set_target_properties(test_grpc_with_mocks PROPERTIES CXX_STANDARD 17)
 add_test(NAME test_grpc_with_mocks COMMAND test_grpc_with_mocks)
 
+# Add test_agent_with_mocks
+add_executable(test_agent_with_mocks test_agent_with_mocks.cpp)
+target_link_libraries(test_agent_with_mocks
+    ${PINPOINT_CPP_LIBRARY}
+    GTest::gmock_main
+)
+set_target_properties(test_agent_with_mocks PROPERTIES CXX_STANDARD 17)
+add_test(NAME test_agent_with_mocks COMMAND test_agent_with_mocks)
+
 # Utility tests
 add_executable(test_utility test_utility.cpp)
 target_link_libraries(test_utility

--- a/test/test_agent_with_mocks.cpp
+++ b/test/test_agent_with_mocks.cpp
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2020-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <chrono>
+#include <thread>
+#include <memory>
+#include <string>
+#include <map>
+
+#include "../src/agent.h"
+#include "../src/grpc.h"
+#include "../src/config.h"
+#include "../src/noop.h"
+#include "../src/span.h"
+#include "../src/stat.h"
+#include "../src/url_stat.h"
+#include "../include/pinpoint/tracer.h"
+#include "v1/Service_mock.grpc.pb.h"
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::NiceMock;
+
+namespace pinpoint {
+
+// --- Testable gRPC classes that bypass real connections ---
+
+class TestableGrpcAgent : public GrpcAgent {
+public:
+    explicit TestableGrpcAgent(std::shared_ptr<const Config> config)
+        : GrpcAgent(std::move(config)) {}
+
+    void injectMockStubs() {
+        auto agent_stub = std::make_unique<NiceMock<v1::MockAgentStub>>();
+        EXPECT_CALL(*agent_stub, RequestAgentInfo(_, _, _))
+            .WillRepeatedly(Return(grpc::Status::OK));
+        set_agent_stub(std::move(agent_stub));
+
+        auto meta_stub = std::make_unique<NiceMock<v1::MockMetadataStub>>();
+        EXPECT_CALL(*meta_stub, RequestApiMetaData(_, _, _))
+            .WillRepeatedly(Return(grpc::Status::OK));
+        EXPECT_CALL(*meta_stub, RequestStringMetaData(_, _, _))
+            .WillRepeatedly(Return(grpc::Status::OK));
+        EXPECT_CALL(*meta_stub, RequestSqlMetaData(_, _, _))
+            .WillRepeatedly(Return(grpc::Status::OK));
+        EXPECT_CALL(*meta_stub, RequestSqlUidMetaData(_, _, _))
+            .WillRepeatedly(Return(grpc::Status::OK));
+        set_meta_stub(std::move(meta_stub));
+    }
+
+    // First call (registration) returns true, subsequent calls (workers) return false
+    // to avoid real gRPC async streaming.
+    bool readyChannel() override { return ready_count_++ == 0; }
+
+    // Override to skip real build_agent_info (which calls slow DNS resolution)
+    GrpcRequestStatus registerAgent() override { return SEND_OK; }
+
+protected:
+    bool wait_channel_ready() const { return true; }
+
+private:
+    std::atomic<int> ready_count_{0};
+};
+
+class TestableGrpcSpan : public GrpcSpan {
+public:
+    explicit TestableGrpcSpan(std::shared_ptr<const Config> config)
+        : GrpcSpan(std::move(config)) {}
+
+    void injectMockStubs() {
+        set_span_stub(std::make_unique<NiceMock<v1::MockSpanStub>>());
+    }
+
+    bool readyChannel() override { return false; }
+
+protected:
+    bool wait_channel_ready() const { return true; }
+};
+
+class TestableGrpcStats : public GrpcStats {
+public:
+    explicit TestableGrpcStats(std::shared_ptr<const Config> config)
+        : GrpcStats(std::move(config)) {}
+
+    void injectMockStubs() {
+        set_stats_stub(std::make_unique<NiceMock<v1::MockStatStub>>());
+    }
+
+    bool readyChannel() override { return false; }
+
+protected:
+    bool wait_channel_ready() const { return true; }
+};
+
+// --- Helper to build a valid Config ---
+
+static std::shared_ptr<Config> make_test_config() {
+    auto cfg = std::make_shared<Config>();
+    cfg->enable = true;
+    cfg->app_name_ = "test-app";
+    cfg->app_type_ = 1300;
+    cfg->agent_id_ = "test-agent-id";
+    cfg->agent_name_ = "test-agent-name";
+    cfg->collector.host = "127.0.0.1";
+    cfg->collector.agent_port = 9991;
+    cfg->collector.span_port = 9993;
+    cfg->collector.stat_port = 9992;
+    cfg->span.queue_size = 1024;
+    cfg->span.event_chunk_size = 10;
+    cfg->span.max_event_depth = 32;
+    cfg->stat.enable = true;
+    cfg->stat.collect_interval = 5000;
+    cfg->http.url_stat.enable = true;
+    cfg->http.url_stat.limit = 1024;
+    cfg->http.url_stat.trim_path_depth = 3;
+    cfg->sampling.type = "counter";
+    cfg->sampling.counter_rate = 1;
+    return cfg;
+}
+
+// --- Helper to create AgentImpl with mock gRPC clients ---
+
+static std::shared_ptr<AgentImpl> make_test_agent(std::shared_ptr<Config> cfg) {
+    auto grpc_agent = std::make_unique<TestableGrpcAgent>(cfg);
+    auto grpc_span = std::make_unique<TestableGrpcSpan>(cfg);
+    auto grpc_stat = std::make_unique<TestableGrpcStats>(cfg);
+
+    grpc_agent->injectMockStubs();
+    grpc_span->injectMockStubs();
+    grpc_stat->injectMockStubs();
+
+    return std::make_shared<AgentImpl>(
+        cfg,
+        std::move(grpc_agent),
+        std::move(grpc_span),
+        std::move(grpc_stat));
+}
+
+// --- Test fixture ---
+
+class AgentImplTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        cfg_ = make_test_config();
+        agent_ = make_test_agent(cfg_);
+        // Wait for init_grpc_workers thread to finish and set enabled_
+        wait_until_enabled();
+    }
+
+    void TearDown() override {
+        if (agent_) {
+            agent_->Shutdown();
+            agent_.reset();
+        }
+    }
+
+    void wait_until_enabled(int timeout_ms = 3000) {
+        wait_agent_enabled(agent_, timeout_ms);
+    }
+
+    static void wait_agent_enabled(const std::shared_ptr<AgentImpl>& agent, int timeout_ms = 3000) {
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+        while (!agent->Enable() && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+    std::shared_ptr<Config> cfg_;
+    std::shared_ptr<AgentImpl> agent_;
+};
+
+// --- Tests ---
+
+TEST_F(AgentImplTest, EnableAfterInit) {
+    EXPECT_TRUE(agent_->Enable());
+}
+
+TEST_F(AgentImplTest, GetConfigReturnsCorrectValues) {
+    EXPECT_EQ(agent_->getAppName(), "test-app");
+    EXPECT_EQ(agent_->getAppType(), 1300);
+    EXPECT_EQ(agent_->getAgentId(), "test-agent-id");
+    EXPECT_EQ(agent_->getAgentName(), "test-agent-name");
+    EXPECT_NE(agent_->getStartTime(), 0);
+}
+
+TEST_F(AgentImplTest, GetConfigReturnsSharedPtr) {
+    auto config = agent_->getConfig();
+    ASSERT_NE(config, nullptr);
+    EXPECT_EQ(config->app_name_, "test-app");
+}
+
+TEST_F(AgentImplTest, GenerateTraceIdIncrementsSequence) {
+    auto tid1 = agent_->generateTraceId();
+    auto tid2 = agent_->generateTraceId();
+
+    EXPECT_EQ(tid1.AgentId, "test-agent-id");
+    EXPECT_EQ(tid2.AgentId, "test-agent-id");
+    EXPECT_EQ(tid1.StartTime, tid2.StartTime);
+    EXPECT_LT(tid1.Sequence, tid2.Sequence);
+}
+
+TEST_F(AgentImplTest, NewSpanReturnsValidSpan) {
+    auto span = agent_->NewSpan("test-op", "/test/rpc");
+    ASSERT_NE(span, nullptr);
+}
+
+TEST_F(AgentImplTest, NewSpanWithReaderReturnsValidSpan) {
+    NoopTraceContextReader reader;
+    auto span = agent_->NewSpan("test-op", "/test/rpc", reader);
+    ASSERT_NE(span, nullptr);
+}
+
+TEST_F(AgentImplTest, NewSpanWithMethodReturnsValidSpan) {
+    NoopTraceContextReader reader;
+    auto span = agent_->NewSpan("test-op", "/test/rpc", "GET", reader);
+    ASSERT_NE(span, nullptr);
+}
+
+TEST_F(AgentImplTest, RecordSpanDoesNotCrash) {
+    auto span_data = std::make_shared<SpanData>(agent_.get(), "test-op");
+    auto span_chunk = std::make_unique<SpanChunk>(span_data, true);
+    agent_->recordSpan(std::move(span_chunk));
+}
+
+TEST_F(AgentImplTest, RecordStatsDoesNotCrash) {
+    agent_->recordStats(AGENT_STATS);
+    agent_->recordStats(URL_STATS);
+}
+
+TEST_F(AgentImplTest, CacheApiReturnsNonZeroId) {
+    int32_t id = agent_->cacheApi("com.example.Api", 100);
+    EXPECT_NE(id, 0);
+}
+
+TEST_F(AgentImplTest, CacheApiReturnsSameIdForSameKey) {
+    int32_t id1 = agent_->cacheApi("com.example.Api", 100);
+    int32_t id2 = agent_->cacheApi("com.example.Api", 100);
+    EXPECT_EQ(id1, id2);
+}
+
+TEST_F(AgentImplTest, CacheApiReturnsDifferentIdForDifferentKeys) {
+    int32_t id1 = agent_->cacheApi("com.example.Api1", 100);
+    int32_t id2 = agent_->cacheApi("com.example.Api2", 100);
+    EXPECT_NE(id1, id2);
+}
+
+TEST_F(AgentImplTest, CacheErrorReturnsNonZeroId) {
+    int32_t id = agent_->cacheError("TestError");
+    EXPECT_NE(id, 0);
+}
+
+TEST_F(AgentImplTest, CacheErrorReturnsSameIdForSameKey) {
+    int32_t id1 = agent_->cacheError("TestError");
+    int32_t id2 = agent_->cacheError("TestError");
+    EXPECT_EQ(id1, id2);
+}
+
+TEST_F(AgentImplTest, CacheSqlReturnsNonZeroId) {
+    int32_t id = agent_->cacheSql("SELECT * FROM test");
+    EXPECT_NE(id, 0);
+}
+
+TEST_F(AgentImplTest, CacheSqlReturnsSameIdForSameQuery) {
+    int32_t id1 = agent_->cacheSql("SELECT 1");
+    int32_t id2 = agent_->cacheSql("SELECT 1");
+    EXPECT_EQ(id1, id2);
+}
+
+TEST_F(AgentImplTest, CacheSqlUidReturnsNonEmpty) {
+    auto uid = agent_->cacheSqlUid("SELECT 1");
+    EXPECT_FALSE(uid.empty());
+}
+
+TEST_F(AgentImplTest, ShutdownDisablesAgent) {
+    EXPECT_TRUE(agent_->Enable());
+    agent_->Shutdown();
+    EXPECT_FALSE(agent_->Enable());
+}
+
+TEST_F(AgentImplTest, ShutdownIsIdempotent) {
+    agent_->Shutdown();
+    agent_->Shutdown();
+    EXPECT_FALSE(agent_->Enable());
+}
+
+TEST_F(AgentImplTest, NewSpanAfterShutdownReturnsNoop) {
+    agent_->Shutdown();
+    auto span = agent_->NewSpan("test-op", "/test/rpc");
+    ASSERT_NE(span, nullptr);
+    // After shutdown, span should be a noop — calling methods should not crash
+    span->SetEndPoint("ep");
+    span->SetRemoteAddress("1.2.3.4");
+    span->EndSpan();
+}
+
+TEST_F(AgentImplTest, CacheApiAfterShutdownReturnsZero) {
+    agent_->Shutdown();
+    int32_t id = agent_->cacheApi("com.example.Api", 100);
+    EXPECT_EQ(id, 0);
+}
+
+TEST_F(AgentImplTest, CacheErrorAfterShutdownReturnsZero) {
+    agent_->Shutdown();
+    int32_t id = agent_->cacheError("TestError");
+    EXPECT_EQ(id, 0);
+}
+
+TEST_F(AgentImplTest, CacheSqlAfterShutdownReturnsZero) {
+    agent_->Shutdown();
+    int32_t id = agent_->cacheSql("SELECT 1");
+    EXPECT_EQ(id, 0);
+}
+
+TEST_F(AgentImplTest, RecordSpanAfterShutdownDoesNotCrash) {
+    agent_->Shutdown();
+    auto span_data = std::make_shared<SpanData>(agent_.get(), "test-op");
+    auto span_chunk = std::make_unique<SpanChunk>(span_data, true);
+    agent_->recordSpan(std::move(span_chunk));
+}
+
+TEST_F(AgentImplTest, RecordStatsAfterShutdownDoesNotCrash) {
+    agent_->Shutdown();
+    agent_->recordStats(AGENT_STATS);
+}
+
+TEST_F(AgentImplTest, IsExitingReflectsShutdown) {
+    EXPECT_FALSE(agent_->isExiting());
+    agent_->Shutdown();
+    EXPECT_TRUE(agent_->isExiting());
+}
+
+// --- URL filter tests ---
+
+TEST_F(AgentImplTest, UrlFilterExcludesMatchingUrl) {
+    auto cfg = make_test_config();
+    cfg->http.server.exclude_url = {"/health", "/status"};
+    auto agent = make_test_agent(cfg);
+    wait_agent_enabled(agent);
+
+    auto span = agent->NewSpan("op", "/health");
+    // /health is filtered — should return noop span
+    // Noop span's End() should not crash
+    span->EndSpan();
+
+    agent->Shutdown();
+}
+
+TEST_F(AgentImplTest, MethodFilterExcludesMatchingMethod) {
+    auto cfg = make_test_config();
+    cfg->http.server.exclude_method = {"OPTIONS"};
+    auto agent = make_test_agent(cfg);
+    wait_agent_enabled(agent);
+
+    NoopTraceContextReader reader;
+    auto span = agent->NewSpan("op", "/api", "OPTIONS", reader);
+    span->EndSpan();
+
+    agent->Shutdown();
+}
+
+// --- Status error tests ---
+
+TEST_F(AgentImplTest, IsStatusFailWithDefault5xx) {
+    // Default config has status_errors = {"5xx"}
+    EXPECT_FALSE(agent_->isStatusFail(200));
+    EXPECT_FALSE(agent_->isStatusFail(404));
+    EXPECT_TRUE(agent_->isStatusFail(500));
+    EXPECT_TRUE(agent_->isStatusFail(503));
+}
+
+TEST_F(AgentImplTest, IsStatusFailWithConfiguredErrors) {
+    auto cfg = make_test_config();
+    cfg->http.server.status_errors = {"500", "503"};
+    auto agent = make_test_agent(cfg);
+    wait_agent_enabled(agent);
+
+    EXPECT_TRUE(agent->isStatusFail(500));
+    EXPECT_TRUE(agent->isStatusFail(503));
+    EXPECT_FALSE(agent->isStatusFail(502));
+    EXPECT_FALSE(agent->isStatusFail(404));
+
+    agent->Shutdown();
+}
+
+// --- ReloadConfig tests ---
+
+TEST_F(AgentImplTest, ReloadConfigUpdatesSampling) {
+    auto new_cfg = make_test_config();
+    new_cfg->sampling.counter_rate = 100;
+    agent_->reloadConfig(new_cfg);
+
+    auto config = agent_->getConfig();
+    EXPECT_EQ(config->sampling.counter_rate, 100);
+}
+
+TEST_F(AgentImplTest, ReloadConfigUpdatesUrlFilter) {
+    auto new_cfg = make_test_config();
+    new_cfg->http.server.exclude_url = {"/excluded"};
+    agent_->reloadConfig(new_cfg);
+
+    auto span = agent_->NewSpan("op", "/excluded");
+    // Should be filtered — noop span
+    span->EndSpan();
+}
+
+// --- Disabled agent test (no background thread startup) ---
+
+class AgentImplDisabledTest : public ::testing::Test {};
+
+TEST_F(AgentImplDisabledTest, DisabledConfigReturnsNotEnabled) {
+    auto cfg = make_test_config();
+    cfg->sampling.counter_rate = 0;
+    auto agent = make_test_agent(cfg);
+
+    // Even after init, sampling rate 0 means no spans are sampled,
+    // but the agent itself is still enabled
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (!agent->Enable() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    // NewSpan should return unsampled span (not noop)
+    auto span = agent->NewSpan("op", "/test");
+    ASSERT_NE(span, nullptr);
+
+    agent->Shutdown();
+}
+
+}  // namespace pinpoint

--- a/test/test_grpc.cpp
+++ b/test/test_grpc.cpp
@@ -187,14 +187,14 @@ protected:
 // GrpcClient Tests
 
 TEST_F(GrpcTest, GrpcClientConstructorTest) {
-    GrpcAgent client(mock_agent_service_.get());
+    GrpcAgent client(mock_agent_service_->getConfig()); client.setAgentService(mock_agent_service_.get());
     
     // Basic construction should not throw
     SUCCEED() << "GrpcClient should construct successfully";
 }
 
 TEST_F(GrpcTest, GrpcClientChannelTest) {
-    GrpcAgent client(mock_agent_service_.get());
+    GrpcAgent client(mock_agent_service_->getConfig()); client.setAgentService(mock_agent_service_.get());
     
     // Test closeChannel should not throw (skip readyChannel as it blocks in test environment)
     client.closeChannel();
@@ -205,13 +205,13 @@ TEST_F(GrpcTest, GrpcClientChannelTest) {
 // GrpcAgent Tests
 
 TEST_F(GrpcTest, GrpcAgentConstructorTest) {
-    GrpcAgent agent(mock_agent_service_.get());
+    GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
     
     SUCCEED() << "GrpcAgent should construct successfully";
 }
 
 TEST_F(GrpcTest, GrpcAgentRegisterAgentTest) {
-    GrpcAgent agent(mock_agent_service_.get());
+    GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
     
     // Skip actual registerAgent call as it blocks without server
     // Just test that the method exists and can be called safely
@@ -219,7 +219,7 @@ TEST_F(GrpcTest, GrpcAgentRegisterAgentTest) {
 }
 
 TEST_F(GrpcTest, GrpcAgentMetaOperationsTest) {
-    GrpcAgent agent(mock_agent_service_.get());
+    GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
     
     // Test enqueueMeta with API metadata
     auto api_meta = std::make_unique<MetaData>(META_API, 1, 100, "test.api");
@@ -233,7 +233,7 @@ TEST_F(GrpcTest, GrpcAgentMetaOperationsTest) {
 }
 
 TEST_F(GrpcTest, GrpcAgentWorkerOperationsTest) {
-    GrpcAgent agent(mock_agent_service_.get());
+    GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
     
     // Test worker stop methods (skip start workers as they block without server)
     agent.stopPingWorker();
@@ -245,13 +245,13 @@ TEST_F(GrpcTest, GrpcAgentWorkerOperationsTest) {
 // GrpcSpan Tests
 
 TEST_F(GrpcTest, GrpcSpanConstructorTest) {
-    GrpcSpan span_client(mock_agent_service_.get());
+    GrpcSpan span_client(mock_agent_service_->getConfig()); span_client.setAgentService(mock_agent_service_.get());
     
     SUCCEED() << "GrpcSpan should construct successfully";
 }
 
 TEST_F(GrpcTest, GrpcSpanEnqueueTest) {
-    GrpcSpan span_client(mock_agent_service_.get());
+    GrpcSpan span_client(mock_agent_service_->getConfig()); span_client.setAgentService(mock_agent_service_.get());
     
     // Create a test span chunk
     auto span_data = std::make_shared<SpanData>(mock_agent_service_.get(), "test-operation");
@@ -264,7 +264,7 @@ TEST_F(GrpcTest, GrpcSpanEnqueueTest) {
 }
 
 TEST_F(GrpcTest, GrpcSpanWorkerOperationsTest) {
-    GrpcSpan span_client(mock_agent_service_.get());
+    GrpcSpan span_client(mock_agent_service_->getConfig()); span_client.setAgentService(mock_agent_service_.get());
     
     // Test worker stop method (skip start worker as it blocks without server)
     span_client.stopSpanWorker();
@@ -275,13 +275,13 @@ TEST_F(GrpcTest, GrpcSpanWorkerOperationsTest) {
 // GrpcStats Tests
 
 TEST_F(GrpcTest, GrpcStatsConstructorTest) {
-    GrpcStats stats_client(mock_agent_service_.get());
+    GrpcStats stats_client(mock_agent_service_->getConfig()); stats_client.setAgentService(mock_agent_service_.get());
     
     SUCCEED() << "GrpcStats should construct successfully";
 }
 
 TEST_F(GrpcTest, GrpcStatsEnqueueTest) {
-    GrpcStats stats_client(mock_agent_service_.get());
+    GrpcStats stats_client(mock_agent_service_->getConfig()); stats_client.setAgentService(mock_agent_service_.get());
     
     // Test enqueueStats
     stats_client.enqueueStats(AGENT_STATS);
@@ -291,7 +291,7 @@ TEST_F(GrpcTest, GrpcStatsEnqueueTest) {
 }
 
 TEST_F(GrpcTest, GrpcStatsWorkerOperationsTest) {
-    GrpcStats stats_client(mock_agent_service_.get());
+    GrpcStats stats_client(mock_agent_service_->getConfig()); stats_client.setAgentService(mock_agent_service_.get());
     
     // Test worker stop method (skip start worker as it blocks without server)
     stats_client.stopStatsWorker();
@@ -358,9 +358,9 @@ TEST_F(GrpcTest, StringMetaSqlTest) {
 // Integration Tests
 
 TEST_F(GrpcTest, GrpcClientTypeTest) {
-    GrpcAgent agent_client(mock_agent_service_.get());
-    GrpcSpan span_client(mock_agent_service_.get());
-    GrpcStats stats_client(mock_agent_service_.get());
+    GrpcAgent agent_client(mock_agent_service_->getConfig()); agent_client.setAgentService(mock_agent_service_.get());
+    GrpcSpan span_client(mock_agent_service_->getConfig()); span_client.setAgentService(mock_agent_service_.get());
+    GrpcStats stats_client(mock_agent_service_->getConfig()); stats_client.setAgentService(mock_agent_service_.get());
     
     // Test that different client types can be created
     SUCCEED() << "All gRPC client types should be constructible";
@@ -368,9 +368,9 @@ TEST_F(GrpcTest, GrpcClientTypeTest) {
 
 TEST_F(GrpcTest, CompleteWorkflowTest) {
     // Create all client types
-    GrpcAgent agent(mock_agent_service_.get());
-    GrpcSpan span_client(mock_agent_service_.get());
-    GrpcStats stats_client(mock_agent_service_.get());
+    GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
+    GrpcSpan span_client(mock_agent_service_->getConfig()); span_client.setAgentService(mock_agent_service_.get());
+    GrpcStats stats_client(mock_agent_service_->getConfig()); stats_client.setAgentService(mock_agent_service_.get());
     
     // Enqueue some data
     auto api_meta = std::make_unique<MetaData>(META_API, 1, 100, "workflow.test");
@@ -413,14 +413,14 @@ TEST_F(GrpcTest, GrpcEnumValuesTest) {
 
 TEST_F(GrpcTest, MultipleClientInstancesTest) {
     // Test that multiple instances can coexist
-    std::unique_ptr<GrpcAgent> agent1 = std::make_unique<GrpcAgent>(mock_agent_service_.get());
-    std::unique_ptr<GrpcAgent> agent2 = std::make_unique<GrpcAgent>(mock_agent_service_.get());
+    std::unique_ptr<GrpcAgent> agent1 = std::make_unique<GrpcAgent>(mock_agent_service_->getConfig());
+    std::unique_ptr<GrpcAgent> agent2 = std::make_unique<GrpcAgent>(mock_agent_service_->getConfig());
     
-    std::unique_ptr<GrpcSpan> span1 = std::make_unique<GrpcSpan>(mock_agent_service_.get());
-    std::unique_ptr<GrpcSpan> span2 = std::make_unique<GrpcSpan>(mock_agent_service_.get());
+    std::unique_ptr<GrpcSpan> span1 = std::make_unique<GrpcSpan>(mock_agent_service_->getConfig());
+    std::unique_ptr<GrpcSpan> span2 = std::make_unique<GrpcSpan>(mock_agent_service_->getConfig());
     
-    std::unique_ptr<GrpcStats> stats1 = std::make_unique<GrpcStats>(mock_agent_service_.get());
-    std::unique_ptr<GrpcStats> stats2 = std::make_unique<GrpcStats>(mock_agent_service_.get());
+    std::unique_ptr<GrpcStats> stats1 = std::make_unique<GrpcStats>(mock_agent_service_->getConfig());
+    std::unique_ptr<GrpcStats> stats2 = std::make_unique<GrpcStats>(mock_agent_service_->getConfig());
     
     // All instances should be valid
     EXPECT_NE(agent1.get(), nullptr);
@@ -555,7 +555,7 @@ TEST_F(GrpcTest, MetaTypeEnumValuesTest) {
 // Queue behavior tests
 
 TEST_F(GrpcTest, GrpcAgentMultipleMetaEnqueueTest) {
-    GrpcAgent agent(mock_agent_service_.get());
+    GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
 
     // Enqueue multiple different metadata types
     agent.enqueueMeta(std::make_unique<MetaData>(META_API, 1, 100, "api1"));
@@ -576,7 +576,7 @@ TEST_F(GrpcTest, GrpcAgentMultipleMetaEnqueueTest) {
 }
 
 TEST_F(GrpcTest, GrpcSpanMultipleEnqueueTest) {
-    GrpcSpan span_client(mock_agent_service_.get());
+    GrpcSpan span_client(mock_agent_service_->getConfig()); span_client.setAgentService(mock_agent_service_.get());
 
     for (int i = 0; i < 5; i++) {
         auto span_data = std::make_shared<SpanData>(mock_agent_service_.get(), "op-" + std::to_string(i));
@@ -588,7 +588,7 @@ TEST_F(GrpcTest, GrpcSpanMultipleEnqueueTest) {
 }
 
 TEST_F(GrpcTest, GrpcStatsEnqueueAllTypesTest) {
-    GrpcStats stats_client(mock_agent_service_.get());
+    GrpcStats stats_client(mock_agent_service_->getConfig()); stats_client.setAgentService(mock_agent_service_.get());
 
     stats_client.enqueueStats(AGENT_STATS);
     stats_client.enqueueStats(URL_STATS);
@@ -600,7 +600,7 @@ TEST_F(GrpcTest, GrpcStatsEnqueueAllTypesTest) {
 // Channel operation tests
 
 TEST_F(GrpcTest, GrpcClientCloseChannelIdempotentTest) {
-    GrpcAgent client(mock_agent_service_.get());
+    GrpcAgent client(mock_agent_service_->getConfig()); client.setAgentService(mock_agent_service_.get());
 
     client.closeChannel();
     client.closeChannel();
@@ -612,7 +612,7 @@ TEST_F(GrpcTest, GrpcClientCloseChannelIdempotentTest) {
 // Worker stop idempotency tests
 
 TEST_F(GrpcTest, GrpcAgentStopWorkersIdempotentTest) {
-    GrpcAgent agent(mock_agent_service_.get());
+    GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
 
     agent.stopPingWorker();
     agent.stopPingWorker();
@@ -623,7 +623,7 @@ TEST_F(GrpcTest, GrpcAgentStopWorkersIdempotentTest) {
 }
 
 TEST_F(GrpcTest, GrpcSpanStopWorkerIdempotentTest) {
-    GrpcSpan span_client(mock_agent_service_.get());
+    GrpcSpan span_client(mock_agent_service_->getConfig()); span_client.setAgentService(mock_agent_service_.get());
 
     span_client.stopSpanWorker();
     span_client.stopSpanWorker();
@@ -632,7 +632,7 @@ TEST_F(GrpcTest, GrpcSpanStopWorkerIdempotentTest) {
 }
 
 TEST_F(GrpcTest, GrpcStatsStopWorkerIdempotentTest) {
-    GrpcStats stats_client(mock_agent_service_.get());
+    GrpcStats stats_client(mock_agent_service_->getConfig()); stats_client.setAgentService(mock_agent_service_.get());
 
     stats_client.stopStatsWorker();
     stats_client.stopStatsWorker();
@@ -682,7 +682,7 @@ TEST_F(GrpcTest, StringMetaLongSqlTest) {
 // Enqueue after service exiting
 
 TEST_F(GrpcTest, GrpcAgentEnqueueMetaWhileExitingTest) {
-    GrpcAgent agent(mock_agent_service_.get());
+    GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
     mock_agent_service_->setExiting(true);
 
     // Should not crash even when service is exiting
@@ -692,7 +692,7 @@ TEST_F(GrpcTest, GrpcAgentEnqueueMetaWhileExitingTest) {
 }
 
 TEST_F(GrpcTest, GrpcSpanEnqueueWhileExitingTest) {
-    GrpcSpan span_client(mock_agent_service_.get());
+    GrpcSpan span_client(mock_agent_service_->getConfig()); span_client.setAgentService(mock_agent_service_.get());
     mock_agent_service_->setExiting(true);
 
     auto span_data = std::make_shared<SpanData>(mock_agent_service_.get(), "exit-op");
@@ -703,7 +703,7 @@ TEST_F(GrpcTest, GrpcSpanEnqueueWhileExitingTest) {
 }
 
 TEST_F(GrpcTest, GrpcStatsEnqueueWhileExitingTest) {
-    GrpcStats stats_client(mock_agent_service_.get());
+    GrpcStats stats_client(mock_agent_service_->getConfig()); stats_client.setAgentService(mock_agent_service_.get());
     mock_agent_service_->setExiting(true);
 
     stats_client.enqueueStats(AGENT_STATS);

--- a/test/test_grpc_with_mocks.cpp
+++ b/test/test_grpc_with_mocks.cpp
@@ -202,8 +202,8 @@ public:
 // Testable gRPC classes that inject mock stubs
 class TestableGrpcAgent : public GrpcAgent {
 public:
-    explicit TestableGrpcAgent(AgentService* agent) : GrpcAgent(agent) {
-        // Don't call parent constructor's stub creation
+    explicit TestableGrpcAgent(AgentService* agent) : GrpcAgent(agent->getConfig()) {
+        agent_ = agent;
     }
 
     void setMockAgentStub(std::unique_ptr<v1::MockAgentStub> mock_stub) {
@@ -228,8 +228,8 @@ protected:
 
 class TestableGrpcSpan : public GrpcSpan {
 public:
-    explicit TestableGrpcSpan(AgentService* agent) : GrpcSpan(agent) {
-        // Don't call parent constructor's stub creation
+    explicit TestableGrpcSpan(AgentService* agent) : GrpcSpan(agent->getConfig()) {
+        agent_ = agent;
     }
 
     void setMockSpanStub(std::unique_ptr<v1::MockSpanStub> mock_stub) {
@@ -250,8 +250,8 @@ protected:
 
 class TestableGrpcStats : public GrpcStats {
 public:
-    explicit TestableGrpcStats(AgentService* agent) : GrpcStats(agent) {
-        // Don't call parent constructor's stub creation
+    explicit TestableGrpcStats(AgentService* agent) : GrpcStats(agent->getConfig()) {
+        agent_ = agent;
     }
 
     void setMockStatsStub(std::unique_ptr<v1::MockStatStub> mock_stub) {

--- a/test/test_grpc_with_mocks.cpp
+++ b/test/test_grpc_with_mocks.cpp
@@ -214,16 +214,18 @@ public:
         set_meta_stub(std::move(mock_stub));
     }
 
-    // Override readyChannel to avoid actual gRPC connection
-    bool readyChannel() {
-        return true; // Always ready for testing
+    // Override readyChannel — controllable per-test
+    bool readyChannel() override {
+        return ready_channel_;
     }
 
+    void setReadyChannel(bool ready) { ready_channel_ = ready; }
+
 protected:
-    // Override wait_channel_ready to always return true for testing
-    bool wait_channel_ready() const {
-        return true; // Always ready for testing
-    }
+    bool wait_channel_ready() const { return true; }
+
+private:
+    bool ready_channel_{true};
 };
 
 class TestableGrpcSpan : public GrpcSpan {
@@ -236,16 +238,14 @@ public:
         set_span_stub(std::move(mock_stub));
     }
 
-    // Override readyChannel to avoid actual gRPC connection
-    bool readyChannel() {
-        return true; // Always ready for testing
-    }
+    bool readyChannel() override { return ready_channel_; }
+    void setReadyChannel(bool ready) { ready_channel_ = ready; }
 
 protected:
-    // Override wait_channel_ready to always return true for testing
-    bool wait_channel_ready() const {
-        return true; // Always ready for testing
-    }
+    bool wait_channel_ready() const { return true; }
+
+private:
+    bool ready_channel_{true};
 };
 
 class TestableGrpcStats : public GrpcStats {
@@ -258,16 +258,14 @@ public:
         set_stats_stub(std::move(mock_stub));
     }
 
-    // Override readyChannel to avoid actual gRPC connection
-    bool readyChannel() {
-        return true; // Always ready for testing
-    }
+    bool readyChannel() override { return ready_channel_; }
+    void setReadyChannel(bool ready) { ready_channel_ = ready; }
 
 protected:
-    // Override wait_channel_ready to always return true for testing
-    bool wait_channel_ready() const {
-        return true; // Always ready for testing
-    }
+    bool wait_channel_ready() const { return true; }
+
+private:
+    bool ready_channel_{true};
 };
 
 class GrpcMockTest : public ::testing::Test {
@@ -340,14 +338,16 @@ TEST_F(GrpcMockTest, GrpcAgentMetaDataEnqueueTest) {
 
 TEST_F(GrpcMockTest, GrpcAgentPingWorkerTest) {
     TestableGrpcAgent agent(mock_agent_service_.get());
-    
+    // readyChannel=false so the worker exits immediately (async streaming
+    // cannot be tested with simple mock stubs)
+    agent.setReadyChannel(false);
+
     auto mock_agent_stub = std::make_unique<NiceMock<v1::MockAgentStub>>();
-    
-    // Since gRPC channel connection will fail in test environment,
-    // we don't expect the stub to be called
+
+    // readyChannel returns false, so no gRPC call is expected
     EXPECT_CALL(*mock_agent_stub, PingSessionRaw(_))
-        .Times(0); // Expect no calls due to channel connection failure
-    
+        .Times(0);
+
     agent.setMockAgentStub(std::move(mock_agent_stub));
     
     // Test ping worker operations
@@ -434,14 +434,15 @@ TEST_F(GrpcMockTest, GrpcSpanEnqueueSpanTest) {
 
 TEST_F(GrpcMockTest, GrpcSpanWorkerTest) {
     TestableGrpcSpan span_client(mock_agent_service_.get());
-    
+    // readyChannel=false so the worker exits immediately (async streaming
+    // cannot be tested with simple mock stubs)
+    span_client.setReadyChannel(false);
+
     auto mock_span_stub = std::make_unique<NiceMock<v1::MockSpanStub>>();
-    
-    // Since gRPC channel connection will fail in test environment,
-    // we don't expect the stub to be called
+
     EXPECT_CALL(*mock_span_stub, SendSpanRaw(_, _))
-        .Times(0); // Expect no calls due to channel connection failure
-    
+        .Times(0);
+
     span_client.setMockSpanStub(std::move(mock_span_stub));
     
     // Create test span data and enqueue
@@ -488,14 +489,15 @@ TEST_F(GrpcMockTest, GrpcStatsEnqueueStatsTest) {
 
 TEST_F(GrpcMockTest, GrpcStatsWorkerTest) {
     TestableGrpcStats stats_client(mock_agent_service_.get());
-    
+    // readyChannel=false so the worker exits immediately (async streaming
+    // cannot be tested with simple mock stubs)
+    stats_client.setReadyChannel(false);
+
     auto mock_stats_stub = std::make_unique<NiceMock<v1::MockStatStub>>();
-    
-    // Since gRPC channel connection will fail in test environment,
-    // we don't expect the stub to be called
+
     EXPECT_CALL(*mock_stats_stub, SendAgentStatRaw(_, _))
-        .Times(0); // Expect no calls due to channel connection failure
-    
+        .Times(0);
+
     stats_client.setMockStatsStub(std::move(mock_stats_stub));
     
     // Enqueue some stats
@@ -566,7 +568,12 @@ TEST_F(GrpcMockTest, CompleteGrpcWorkflowWithWorkersTest) {
     // Test complete workflow
     GrpcRequestStatus register_status = agent.registerAgent();
     EXPECT_EQ(register_status, SEND_OK);
-    
+
+    // Disable readyChannel for workers (async streaming cannot be tested with mock stubs)
+    agent.setReadyChannel(false);
+    span_client.setReadyChannel(false);
+    stats_client.setReadyChannel(false);
+
     // Start workers
     std::thread ping_worker([&agent]() { agent.sendPingWorker(); });
     std::thread meta_worker([&agent]() { agent.sendMetaWorker(); });
@@ -632,16 +639,21 @@ TEST_F(GrpcMockTest, AllWorkersStartStopTest) {
     agent.setMockMetaStub(std::move(mock_meta_stub));
     span_client.setMockSpanStub(std::move(mock_span_stub));
     stats_client.setMockStatsStub(std::move(mock_stats_stub));
-    
+
+    // Disable readyChannel for workers (async streaming cannot be tested with mock stubs)
+    agent.setReadyChannel(false);
+    span_client.setReadyChannel(false);
+    stats_client.setReadyChannel(false);
+
     // Start all workers
     std::thread ping_worker([&agent]() { agent.sendPingWorker(); });
     std::thread meta_worker([&agent]() { agent.sendMetaWorker(); });
     std::thread span_worker([&span_client]() { span_client.sendSpanWorker(); });
     std::thread stats_worker([&stats_client]() { stats_client.sendStatsWorker(); });
-    
+
     // Let workers run briefly
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    
+
     // Set agent to exiting state before stopping workers
     mock_agent_service_->setExiting(true);
     


### PR DESCRIPTION
## Changes

### Dependency Injection
- Modified `GrpcClient` to accept `Config` via constructor instead of `AgentService*`
- Added `setAgentService()` method to inject `AgentService` after construction
- Updated `GrpcAgent`, `GrpcSpan`, and `GrpcStats` constructors to follow the same pattern

### AgentImpl Updates
- Modified `AgentImpl` constructor to accept pre-constructed gRPC client instances
- Moved gRPC client instantiation from `init_grpc_workers()` to `makeAgent()` factory
- Replaced global `build_grpc_context()` and `build_agent_info()` with class methods

### Testing
- Added comprehensive unit tests in `test_agent_with_mocks.cpp` (444 lines)
- Tests cover initialization, span/stats recording, caching, configuration, and shutdown behavior
- Updated existing tests in `test_grpc.cpp` and `test_grpc_with_mocks.cpp` to use new constructor signatures
- Created testable gRPC classes that can inject mock stubs and control channel readiness

### Benefits
- **Improved testability**: Easy to inject mock gRPC clients for unit testing
- **Better separation of concerns**: Config dependencies decoupled from AgentService
- **More flexible initialization**: Clients can be configured before agent service is available
