### PR TITLE
Replace mapfile with while-read loop in it_test.sh

### DIFF
--- a/test/it_test/it_test.sh
+++ b/test/it_test/it_test.sh
@@ -186,7 +186,10 @@ check_endpoint "gRPC"  "${BASE_URL}/grpc-unary" || echo "WARNING: gRPC endpoints
 check_endpoint "SQL"   "${BASE_URL}/db-crud" || echo "WARNING: SQL-traced endpoints not available."
 echo ""
 
-mapfile -t URLS < <(build_urls)
+URLS=()
+while IFS= read -r line; do
+    URLS+=("$line")
+done < <(build_urls)
 URL_COUNT=${#URLS[@]}
 
 # Worker function: sends requests in a loop


### PR DESCRIPTION
## Summary
- Replace `mapfile -t` with `while IFS= read -r` loop in `test/it_test/it_test.sh` for bash 3.x compatibility
- `mapfile` (aka `readarray`) requires bash 4.0+, which is not available on older systems (e.g., macOS default bash)
