### PR TITLE
Fix Bazel build: add fmt dependency and test targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -28,5 +28,6 @@ cc_library(
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_jbeder_yaml_cpp//:yaml-cpp",
         "@com_google_absl//absl/strings",
+        "@fmt",
     ],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,4 +10,5 @@ bazel_dep(name = "protobuf", version = "29.2", repo_name = "com_google_protobuf"
 bazel_dep(name = "grpc", version = "1.63.1", repo_name = "com_github_grpc_grpc")
 bazel_dep(name = "yaml-cpp", version = "0.8.0", repo_name = "com_github_jbeder_yaml_cpp")
 bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
+bazel_dep(name = "fmt", version = "11.1.4")
 bazel_dep(name = "googletest", version = "1.17.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -50,6 +50,8 @@
     "https://bcr.bazel.build/modules/c-ares/1.15.0/source.json": "5e3ed991616c5ec4cc09b0893b29a19232de4a1830eb78c567121bfea87453f7",
     "https://bcr.bazel.build/modules/curl/8.4.0/MODULE.bazel": "0bc250aa1cb69590049383df7a9537c809591fcf876c620f5f097c58fdc9bc10",
     "https://bcr.bazel.build/modules/curl/8.4.0/source.json": "8b9532397af6a24be4ec118d8637b1f4e3e5a0d4be672c94b2275d675c7f7d6b",
+    "https://bcr.bazel.build/modules/fmt/11.1.4/MODULE.bazel": "514019a3848f2764cc7aba3f388cd2f54d5d8c6249ddd33a143f37da9ebe66a4",
+    "https://bcr.bazel.build/modules/fmt/11.1.4/source.json": "94756c79709d889323996650a371bbad133a0628e54de3cae229e99275abfc9e",
     "https://bcr.bazel.build/modules/gazelle/0.27.0/MODULE.bazel": "3446abd608295de6d90b4a8a118ed64a9ce11dcb3dda2dc3290a22056bd20996",
     "https://bcr.bazel.build/modules/gazelle/0.30.0/MODULE.bazel": "f888a1effe338491f35f0e0e85003b47bb9d8295ccba73c37e07702d8d31c65b",
     "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",

--- a/example/BUILD
+++ b/example/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 cc_library(
     name = "example_common",
     hdrs = ["http_trace_context.h"],
+    includes = ["."],
     deps = [
         "//:pinpoint-cpp",
         "//3rd_party:httplib",

--- a/test/BUILD
+++ b/test/BUILD
@@ -6,7 +6,12 @@ licenses(["notice"])  # Apache 2
 cc_library(
     name = "test_common",
     testonly = True,
+    hdrs = [
+        "mock_agent_service.h",
+        "mock_helpers.h",
+    ],
     includes = [
+        ".",
         "../src",
     ],
     deps = [
@@ -20,7 +25,12 @@ cc_library(
 cc_library(
     name = "test_gmock",
     testonly = True,
+    hdrs = [
+        "mock_agent_service.h",
+        "mock_helpers.h",
+    ],
     includes = [
+        ".",
         "../src",
     ],
     deps = [

--- a/test/it_test/BUILD
+++ b/test/it_test/BUILD
@@ -1,0 +1,64 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2
+
+proto_library(
+    name = "testapp_proto",
+    srcs = ["testapp.proto"],
+)
+
+cc_proto_library(
+    name = "testapp_proto_cc",
+    deps = [":testapp_proto"],
+)
+
+cc_grpc_library(
+    name = "testapp_grpc_cc",
+    srcs = [":testapp_proto"],
+    grpc_only = True,
+    deps = [":testapp_proto_cc"],
+)
+
+_PROTO_COPTS = [
+    "-Itest/it_test",
+    "-I$(GENDIR)/test/it_test",
+]
+
+# gRPC server (standalone)
+cc_binary(
+    name = "grpc_server",
+    srcs = [
+        "grpc_server.cpp",
+        "pinpoint_grpc_context.h",
+        "pinpoint_grpc_interceptors.h",
+    ],
+    copts = _PROTO_COPTS,
+    deps = [
+        ":testapp_grpc_cc",
+        "//:pinpoint-cpp",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_grpc_grpc//:grpc++_reflection",
+    ],
+)
+
+# it_test_server (HTTP + gRPC client + SQL tracing)
+cc_binary(
+    name = "it_test_server",
+    srcs = [
+        "it_test_server.cpp",
+        "pinpoint_grpc_context.h",
+        "pinpoint_grpc_interceptors.h",
+    ],
+    copts = _PROTO_COPTS,
+    deps = [
+        ":testapp_grpc_cc",
+        "//:pinpoint-cpp",
+        "//3rd_party:httplib",
+        "//example:example_common",
+        "@com_github_grpc_grpc//:grpc++",
+    ],
+)


### PR DESCRIPTION
## Changes

- **Added fmt dependency**: Declared `fmt` v11.1.4 in MODULE.bazel and added it to BUILD.bazel dependencies
- **Updated MODULE.bazel.lock**: Added fmt module lockfile entries
- **Fixed test headers**: Exposed `mock_agent_service.h` and `mock_helpers.h` in test targets and added local includes
- **Fixed example headers**: Added includes directive to `example_common` library
- **Created it_test targets**: Added new BUILD file for integration tests with:
  - Proto library definitions for `testapp.proto`
  - gRPC server binary
  - Integration test server binary with HTTP and gRPC support