### PR TITLE
Replace atomic_load/atomic_store with AtomicSharedPtr wrapper

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -39,7 +39,7 @@ namespace pinpoint {
                          std::unique_ptr<GrpcAgent> grpc_agent,
                          std::unique_ptr<GrpcSpan> grpc_span,
                          std::unique_ptr<GrpcStats> grpc_stat) :
-        config_(std::move(cfg)),
+        config_(std::shared_ptr<const Config>(std::move(cfg))),
         grpc_agent_(std::move(grpc_agent)),
         grpc_span_(std::move(grpc_span)),
         grpc_stat_(std::move(grpc_stat)),
@@ -54,33 +54,33 @@ namespace pinpoint {
         sql_cache_ = std::make_unique<IdCache>(kCacheSize);
         sql_uid_cache_ = std::make_unique<SqlUidCache>(kCacheSize);
         
-        reloadConfig(config_);
+        reloadConfig(config_.load());
 
         init_thread_ = std::thread{&AgentImpl::init_grpc_workers, this};
         start_config_file_watcher();
     }
 
     std::shared_ptr<const Config> AgentImpl::getConfig() const {
-        return std::atomic_load(&config_);
+        return config_.load();
     }
 
     std::string AgentImpl::getAppName() const {
-        const auto cfg = std::atomic_load(&config_);
+        const auto cfg = config_.load();
         return cfg->app_name_;
     }
 
     int32_t AgentImpl::getAppType() const {
-        const auto cfg = std::atomic_load(&config_);
+        const auto cfg = config_.load();
         return cfg->app_type_;
     }
 
     std::string AgentImpl::getAgentId() const {
-        const auto cfg = std::atomic_load(&config_);
+        const auto cfg = config_.load();
         return cfg->agent_id_;
     }
 
     std::string AgentImpl::getAgentName() const {
-        const auto cfg = std::atomic_load(&config_);
+        const auto cfg = config_.load();
         return cfg->agent_name_;
     }
 
@@ -122,14 +122,14 @@ namespace pinpoint {
         }
 
         for (size_t i = 0; i < 3; ++i) {
-            std::atomic_store(&http_srv_header_recorder_[i], new_srv[i]);
-            std::atomic_store(&http_cli_header_recorder_[i], new_cli[i]);
+            http_srv_header_recorder_[i].store(new_srv[i]);
+            http_cli_header_recorder_[i].store(new_cli[i]);
         }
     }
 
     void AgentImpl::reloadConfig(std::shared_ptr<const Config> cfg) {
-        std::atomic_store(&config_, std::move(cfg));
-        const auto local_cfg = std::atomic_load(&config_);
+        config_.store(std::move(cfg));
+        const auto local_cfg = config_.load();
 
         // Rebuild sampler
         std::unique_ptr<Sampler> sampler;
@@ -147,26 +147,26 @@ namespace pinpoint {
         } else {
             new_sampler = std::make_shared<BasicTraceSampler>(this, std::move(sampler));
         }
-        std::atomic_store(&sampler_, new_sampler);
+        sampler_.store(std::move(new_sampler));
 
         // Rebuild HTTP filters
         std::shared_ptr<HttpUrlFilter> new_url_filter;
         if (!local_cfg->http.server.exclude_url.empty()) {
             new_url_filter = std::make_shared<HttpUrlFilter>(local_cfg->http.server.exclude_url);
         }
-        std::atomic_store(&http_url_filter_, new_url_filter);
+        http_url_filter_.store(std::move(new_url_filter));
 
         std::shared_ptr<HttpMethodFilter> new_method_filter;
         if (!local_cfg->http.server.exclude_method.empty()) {
             new_method_filter = std::make_shared<HttpMethodFilter>(local_cfg->http.server.exclude_method);
         }
-        std::atomic_store(&http_method_filter_, new_method_filter);
+        http_method_filter_.store(std::move(new_method_filter));
 
         std::shared_ptr<HttpStatusErrors> new_status_errors;
         if (!local_cfg->http.server.status_errors.empty()) {
             new_status_errors = std::make_shared<HttpStatusErrors>(local_cfg->http.server.status_errors);
         }
-        std::atomic_store(&http_status_errors_, new_status_errors);
+        http_status_errors_.store(std::move(new_status_errors));
 
         // Rebuild header recorders
         init_header_recorders(local_cfg);
@@ -284,11 +284,11 @@ namespace pinpoint {
         if (!enabled_) {
             return noopSpan();
         }
-        const auto url_filter = std::atomic_load(&http_url_filter_);
+        const auto url_filter = http_url_filter_.load();
         if (url_filter && url_filter->isFiltered(rpc_point)) {
             return noopSpan();
         }
-        const auto method_filter = std::atomic_load(&http_method_filter_);
+        const auto method_filter = http_method_filter_.load();
         if (!method.empty() && method_filter && method_filter->isFiltered(method)) {
             return noopSpan();
         }
@@ -297,7 +297,7 @@ namespace pinpoint {
             return std::make_shared<UnsampledSpan>(this);
         }
 
-        auto sampler = std::atomic_load(&sampler_);
+        auto sampler = sampler_.load();
         if (!sampler) {
             return noopSpan();
         }
@@ -492,7 +492,7 @@ namespace pinpoint {
     }
 
     bool AgentImpl::isStatusFail(const int status) const {
-        const auto status_errors = std::atomic_load(&http_status_errors_);
+        const auto status_errors = http_status_errors_.load();
         if (enabled_ && status_errors) {
             return status_errors->isErrorCode(status);
         }
@@ -503,7 +503,7 @@ namespace pinpoint {
         if (which < HTTP_REQUEST || which > HTTP_COOKIE) {
             return;
         }
-        const auto recorder = std::atomic_load(&http_srv_header_recorder_[which]);
+        const auto recorder = http_srv_header_recorder_[which].load();
         if (enabled_ && recorder) {
             recorder->recordHeader(reader, annotation);
         }
@@ -513,7 +513,7 @@ namespace pinpoint {
         if (which < HTTP_REQUEST || which > HTTP_COOKIE) {
             return;
         }
-        const auto recorder = std::atomic_load(&http_cli_header_recorder_[which]);
+        const auto recorder = http_cli_header_recorder_[which].load();
         if (enabled_ && recorder) {
             recorder->recordHeader(reader, annotation);
         }

--- a/src/agent.h
+++ b/src/agent.h
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include "pinpoint/tracer.h"
+#include "atomic_shared_ptr.h"
 #include "config.h"
 #include "http.h"
 #include "cache.h"
@@ -116,8 +117,8 @@ namespace pinpoint {
 
     private:
 
-        std::shared_ptr<const Config> config_;
-        std::shared_ptr<TraceSampler> sampler_{};
+        AtomicSharedPtr<const Config> config_;
+        AtomicSharedPtr<TraceSampler> sampler_;
     	std::unique_ptr<IdCache> api_cache_{};
     	std::unique_ptr<IdCache> error_cache_{};
     	std::unique_ptr<IdCache> sql_cache_{};
@@ -138,11 +139,11 @@ namespace pinpoint {
     	std::thread url_stat_send_thread_;
     	std::thread agent_stat_thread_;
 
-    	std::shared_ptr<HttpUrlFilter> http_url_filter_{};
-    	std::shared_ptr<HttpMethodFilter> http_method_filter_{};
-    	std::shared_ptr<HttpStatusErrors> http_status_errors_{};
-    	std::shared_ptr<HttpHeaderRecorder> http_srv_header_recorder_[3]{};
-    	std::shared_ptr<HttpHeaderRecorder> http_cli_header_recorder_[3]{};
+    	AtomicSharedPtr<HttpUrlFilter> http_url_filter_;
+    	AtomicSharedPtr<HttpMethodFilter> http_method_filter_;
+    	AtomicSharedPtr<HttpStatusErrors> http_status_errors_;
+    	AtomicSharedPtr<HttpHeaderRecorder> http_srv_header_recorder_[3];
+    	AtomicSharedPtr<HttpHeaderRecorder> http_cli_header_recorder_[3];
 
         int64_t start_time_{};
     	std::atomic<uint64_t> trace_id_sequence_{};

--- a/src/atomic_shared_ptr.h
+++ b/src/atomic_shared_ptr.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <shared_mutex>
+
+namespace pinpoint {
+
+    /**
+     * @brief Thread-safe wrapper around std::shared_ptr using std::shared_mutex.
+     *
+     * Provides the same interface as std::atomic<std::shared_ptr<T>> (C++20),
+     * working around the missing libc++ specialization on Apple platforms.
+     * Can be replaced with std::atomic<std::shared_ptr<T>> once libc++ adds support.
+     */
+    template <typename T>
+    class AtomicSharedPtr {
+    public:
+        AtomicSharedPtr() = default;
+        explicit AtomicSharedPtr(std::shared_ptr<T> ptr) : ptr_(std::move(ptr)) {}
+
+        AtomicSharedPtr(const AtomicSharedPtr&) = delete;
+        AtomicSharedPtr& operator=(const AtomicSharedPtr&) = delete;
+
+        std::shared_ptr<T> load() const {
+            std::shared_lock lock(mutex_);
+            return ptr_;
+        }
+
+        void store(std::shared_ptr<T> desired) {
+            std::unique_lock lock(mutex_);
+            ptr_ = std::move(desired);
+        }
+
+    private:
+        mutable std::shared_mutex mutex_;
+        std::shared_ptr<T> ptr_;
+    };
+
+}  // namespace pinpoint


### PR DESCRIPTION
## Changes

- **New file**: `src/atomic_shared_ptr.h` - Introduces `AtomicSharedPtr<T>` template class providing thread-safe `shared_ptr` operations using `shared_mutex`. This works around missing `std::atomic<std::shared_ptr<T>>` support in libc++ on Apple platforms.

- **Updated**: `src/agent.h` - Replaces raw `std::shared_ptr` members with `AtomicSharedPtr` wrapper for:
  - `config_`
  - `sampler_`
  - `http_url_filter_`
  - `http_method_filter_`
  - `http_status_errors_`
  - `http_srv_header_recorder_[3]`
  - `http_cli_header_recorder_[3]`

- **Updated**: `src/agent.cpp` - Replaces all `std::atomic_load()` and `std::atomic_store()` calls with `.load()` and `.store()` methods on `AtomicSharedPtr` instances. Improves code clarity and consistency.

## Benefits

- Cleaner API: `.load()` and `.store()` instead of `std::atomic_load()`/`std::atomic_store()`
- Cross-platform compatibility without relying on C++20 atomic specializations
- Thread-safe shared pointer access with explicit lock semantics