### PR TITLE
Fix documentation inaccuracies and align dependency versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ if(NOT gRPC_FOUND OR NOT Protobuf_FOUND)
   FetchContent_Declare(
     gRPC
     GIT_REPOSITORY https://github.com/grpc/grpc.git
-    GIT_TAG        v1.66.0
+    GIT_TAG        v1.63.1
   )
   set(FETCHCONTENT_QUIET OFF)
   set(gRPC_BUILD_TESTS OFF CACHE BOOL "" FORCE)
@@ -190,7 +190,7 @@ if(NOT fmt_FOUND)
   FetchContent_Declare(
     fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG        11.0.2
+    GIT_TAG        11.1.4
   )
   FetchContent_MakeAvailable(fmt)
 else()

--- a/doc/config.md
+++ b/doc/config.md
@@ -176,7 +176,8 @@ int main() {
 |---|---|---|---|---|
 | `Http.CollectUrlStat` | `PINPOINT_CPP_HTTP_COLLECT_URL_STAT` | bool | `false` | Enable URL statistics collection. |
 | `Http.UrlStatLimit` | `PINPOINT_CPP_HTTP_URL_STAT_LIMIT` | int | `1024` | Max unique URLs to track. |
-| `Http.UrlStatPathDepth` | `PINPOINT_CPP_HTTP_URL_STAT_PATH_DEPTH` | int | `1` | URL path depth for normalisation (e.g., depth 2: `/api/users` → `/api/*`). |
+| `Http.UrlStatEnableTrimPath` | `PINPOINT_CPP_HTTP_URL_STAT_ENABLE_TRIM_PATH` | bool | `true` | Enable URL path trimming for normalisation. |
+| `Http.UrlStatTrimPathDepth` | `PINPOINT_CPP_HTTP_URL_STAT_TRIM_PATH_DEPTH` | int | `1` | URL path depth for normalisation (e.g., depth 2: `/api/users` → `/api/*`). Requires `UrlStatEnableTrimPath: true`. |
 | `Http.UrlStatMethodPrefix` | `PINPOINT_CPP_HTTP_URL_STAT_METHOD_PREFIX` | bool | `false` | Prefix URL stat key with HTTP method (e.g., `GET:/api/users`). |
 
 ### Server-side Tracing
@@ -316,7 +317,7 @@ Collector:
   GrpcStatPort: 9992
 
 Sampling:
-  Type: "COUNTING"
+  Type: "COUNTER"
   CounterRate: 1  # sample all
 
 Http:
@@ -553,7 +554,8 @@ Span:
 Http:
   CollectUrlStat: false
   UrlStatLimit: 1024
-  UrlStatPathDepth: 1
+  UrlStatEnableTrimPath: true
+  UrlStatTrimPathDepth: 1
   UrlStatMethodPrefix: false
   Server:
     StatusCodeErrors: ["5xx"]

--- a/doc/instrument.md
+++ b/doc/instrument.md
@@ -303,10 +303,39 @@ if (span_event) {
 }
 ```
 
+### RAII Helper: `helper::ScopedSpanEvent`
+
+The `helper::ScopedSpanEvent` class automatically calls `EndSpanEvent()` when it goes out of scope, preventing dangling events:
+
+```cpp
+#include "pinpoint/tracer.h"
+
+void processRequest(pinpoint::SpanPtr span) {
+    // Automatically ends when 'guard' goes out of scope
+    pinpoint::helper::ScopedSpanEvent guard(span, "processRequest");
+
+    // Access the underlying SpanEvent via operator-> or value()
+    guard->SetDestination("backend-service");
+    guard->SetEndPoint("localhost:9000");
+
+    // No need to call span->EndSpanEvent() — destructor handles it
+}
+
+// With a custom service type
+void queryDatabase(pinpoint::SpanPtr span) {
+    pinpoint::helper::ScopedSpanEvent guard(span, "SQL_SELECT", pinpoint::SERVICE_TYPE_MYSQL_QUERY);
+    guard->SetEndPoint("mysql-server:3306");
+    guard->SetDestination("user_database");
+
+    // Even if an exception is thrown, EndSpanEvent() is called
+    database->execute("SELECT * FROM users");
+}
+```
+
 ### Recommendations
 
 - Create **one span event per major logical step**.
-- Always pair `NewSpanEvent()` with `EndSpanEvent()` — prefer RAII where possible.
+- Always pair `NewSpanEvent()` with `EndSpanEvent()` — prefer `helper::ScopedSpanEvent` for automatic cleanup.
 - Use appropriate `SERVICE_TYPE_*` constants for downstream services.
 - Call `EndSpanEvent()` in the same scope or via RAII wrappers to avoid dangling events.
 
@@ -605,6 +634,66 @@ span->RecordHeader(pinpoint::HTTP_REQUEST, header_reader);
 span->RecordHeader(pinpoint::HTTP_RESPONSE, response_header_reader);
 ```
 
+### HTTP Tracing Helpers
+
+The `helper` namespace provides convenience functions that bundle common HTTP tracing steps into single calls:
+
+```cpp
+#include "pinpoint/tracer.h"
+
+void handleRequest(const httplib::Request& req, httplib::Response& res) {
+    HttpTraceContextReader trace_reader(req.headers);
+    auto agent = pinpoint::GlobalAgent();
+    auto span = agent->NewSpan("HTTP Server", req.path, req.method, trace_reader);
+
+    // Server request: sets remote address, endpoint, and records request headers in one call
+    HttpHeaderReader request_headers(req.headers);
+    pinpoint::helper::TraceHttpServerRequest(span, req.remote_addr, req.get_header_value("Host"), request_headers);
+
+    // With cookie recording
+    // HttpHeaderReader cookie_reader(req.cookies);
+    // pinpoint::helper::TraceHttpServerRequest(span, req.remote_addr, endpoint, request_headers, cookie_reader);
+
+    // ... business logic ...
+
+    // Server response: sets status code, records URL stat, and records response headers
+    HttpHeaderReader response_headers(res.headers);
+    pinpoint::helper::TraceHttpServerResponse(span, req.matched_route, req.method, res.status, response_headers);
+
+    span->EndSpan();
+}
+```
+
+For outgoing HTTP client calls:
+
+```cpp
+void callExternalService(pinpoint::SpanPtr span) {
+    auto se = span->NewSpanEvent("HTTP_CLIENT");
+    se->SetServiceType(pinpoint::SERVICE_TYPE_CPP_HTTP_CLIENT);
+
+    HttpHeaderReader request_headers(headers);
+    pinpoint::helper::TraceHttpClientRequest(se, "api.example.com", "/users", request_headers);
+
+    // ... make HTTP request ...
+
+    HttpHeaderReader response_headers(res.headers);
+    pinpoint::helper::TraceHttpClientResponse(se, res.status, response_headers);
+
+    span->EndSpanEvent();
+}
+```
+
+**Available helper functions:**
+
+| Function | Description |
+|---|---|
+| `TraceHttpServerRequest(span, remote_addr, endpoint, header_reader)` | Sets remote address, endpoint, and records request headers |
+| `TraceHttpServerRequest(span, remote_addr, endpoint, header_reader, cookie_reader)` | Same as above, plus records cookies |
+| `TraceHttpServerResponse(span, url_pattern, method, status_code, response_reader)` | Sets status code, URL stat, and records response headers |
+| `TraceHttpClientRequest(span_event, host, url, header_reader)` | Sets endpoint, destination, and records request headers |
+| `TraceHttpClientRequest(span_event, host, url, header_reader, cookie_reader)` | Same as above, plus records cookies |
+| `TraceHttpClientResponse(span_event, status_code, response_reader)` | Records status code and response headers |
+
 ### URL Statistics
 
 Collect URL statistics for monitoring:
@@ -695,7 +784,7 @@ pinpoint::SERVICE_TYPE_CASSANDRA_QUERY  // Cassandra
 - Wrap DB access in helper methods so every query is traced consistently.
 - Use the correct `SERVICE_TYPE_*` constant for the backend.
 - Sanitize SQL text and parameters before recording — never log passwords or secrets.
-- See `example/db_demo.cpp` for a full working example.
+- See `example/tutorial.cpp` for a full working example.
 
 ---
 
@@ -923,7 +1012,7 @@ Samples 1 out of every N transactions using an atomic counter. Simple and predic
 
 ```yaml
 Sampling:
-  Type: "COUNTING"
+  Type: "COUNTER"
   CounterRate: 10  # Sample 1 out of every 10 new transactions
 ```
 
@@ -985,7 +1074,7 @@ In a distributed system, sampling decisions flow from the root service to all do
 
 ```yaml
 Sampling:
-  Type: "COUNTING"
+  Type: "COUNTER"
   CounterRate: 1
 ```
 
@@ -1011,7 +1100,7 @@ Sampling:
 
 ```yaml
 Sampling:
-  Type: "COUNTING"
+  Type: "COUNTER"
   CounterRate: 1  # Sample all, revert after debugging
 ```
 
@@ -1236,7 +1325,7 @@ For more detailed troubleshooting, see the [Troubleshooting Guide](trouble_shoot
 - [Configuration Guide](config.md)
 - [Quick Start Guide](quick_start.md)
 - [Troubleshooting Guide](trouble_shooting.md)
-- Complete examples: see the `example/` directory (`http_server.cpp`, `web_demo.cpp`, `db_demo.cpp`)
+- Complete examples: see the `example/` directory (`http_server.cpp`, `tutorial.cpp`)
 - API header: `include/pinpoint/tracer.h`
 - GitHub: [pinpoint-apm/pinpoint-cpp-agent](https://github.com/pinpoint-apm/pinpoint-cpp-agent)
 - Pinpoint APM Docs: [https://pinpoint-apm.github.io/pinpoint/](https://pinpoint-apm.github.io/pinpoint/)

--- a/doc/quick_start.md
+++ b/doc/quick_start.md
@@ -24,7 +24,7 @@ Before you begin, ensure you have:
 
 - **Pinpoint Collector**: Version 2.4.0 or higher
 - **C++ Compiler**: Supporting C++17 or higher
-- **Build System**: CMake 3.14+ or Bazel
+- **Build System**: CMake 3.20+ or Bazel
 - **Operating System**: Linux, macOS, or Windows
 
 ---
@@ -91,7 +91,7 @@ Collector:
   GrpcStatPort: 9992         # gRPC stat port
 
 Sampling:
-  Type: "COUNTING"
+  Type: "COUNTER"
   CounterRate: 1             # Sample all requests
 
 Log:
@@ -328,7 +328,7 @@ g++ -std=c++17 -o my_app my_app.cpp -lpinpoint_cpp
 
 This example shows how to instrument an HTTP server to trace incoming requests and outgoing calls. It uses `httplib` and demonstrates context propagation.
 
-See full example: `example/web_demo.cpp`
+See full example: `example/http_server.cpp`
 
 ```cpp
 #include "pinpoint/tracer.h"
@@ -380,7 +380,7 @@ int main() {
 
 This example demonstrates tracing database operations (e.g., MySQL). It shows how to create `SpanEvent`s for SQL queries.
 
-See full example: `example/mysql_demo/db_demo.cpp`
+See full example: `example/tutorial.cpp`
 
 ```cpp
 // Helper to trace DB operations
@@ -391,7 +391,7 @@ void trace_db_op(pinpoint::SpanPtr span,
     se->SetServiceType(pinpoint::SERVICE_TYPE_MYSQL_QUERY);
     se->SetEndPoint("localhost:33060");
     se->SetDestination("test_db");
-    se->SetSqlQuery(query);  // Record the query string (sanitize in production)
+    se->SetSqlQuery(query, "");  // Record the query string (sanitize in production)
 
     try {
         func();  // Execute actual DB operation
@@ -424,7 +424,7 @@ Now that you have a basic understanding of the Pinpoint C++ Agent, you can:
 
 1. **Learn Advanced Instrumentation**: Read the [Instrumentation Guide](instrument.md) for detailed information on HTTP request/response tracing, database query tracing, distributed tracing with context propagation, error handling and exception tracking, and asynchronous operation tracing.
 
-2. **Explore Examples**: Check the `example/` directory for complete examples including `http_server.cpp` (HTTP server instrumentation), `web_demo.cpp` (web application with outgoing HTTP calls), and `db_demo.cpp` (database query instrumentation).
+2. **Explore Examples**: Check the `example/` directory for complete examples including `http_server.cpp` (HTTP server instrumentation) and `tutorial.cpp` (database query and tracing tutorial).
 
 3. **Configure Advanced Options**: See the [Configuration Guide](config.md) for sampling strategies, URL statistics collection, SQL parameter binding, logging, and stat collection.
 

--- a/doc/trouble_shooting.md
+++ b/doc/trouble_shooting.md
@@ -313,7 +313,7 @@ if (!agent->Enable()) {
 
    ```yaml
    Sampling:
-     Type: "COUNTING"
+     Type: "COUNTER"
      CounterRate: 1  # Sample all transactions
    ```
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -722,7 +722,7 @@ namespace pinpoint {
         emitter << YAML::Key << "CounterRate" << YAML::Value << config.sampling.counter_rate;
         emitter << YAML::Key << "PercentRate" << YAML::Value << config.sampling.percent_rate;
         emitter << YAML::Key << "NewThroughput" << YAML::Value << config.sampling.new_throughput;
-        emitter << YAML::Key << "ContThroughput" << YAML::Value << config.sampling.cont_throughput;
+        emitter << YAML::Key << "ContinueThroughput" << YAML::Value << config.sampling.cont_throughput;
         emitter << YAML::EndMap;
 
         emitter << YAML::Key << "Span";
@@ -736,13 +736,11 @@ namespace pinpoint {
         emitter << YAML::Key << "Http";
         emitter << YAML::BeginMap;
 
-        emitter << YAML::Key << "UrlStat";
-        emitter << YAML::BeginMap;
-        emitter << YAML::Key << "Enable" << YAML::Value << config.http.url_stat.enable;
-        emitter << YAML::Key << "Limit" << YAML::Value << config.http.url_stat.limit;
-        emitter << YAML::Key << "PathDepth" << YAML::Value << config.http.url_stat.trim_path_depth;
-        emitter << YAML::Key << "MethodPrefix" << YAML::Value << config.http.url_stat.method_prefix;
-        emitter << YAML::EndMap;
+        emitter << YAML::Key << "CollectUrlStat" << YAML::Value << config.http.url_stat.enable;
+        emitter << YAML::Key << "UrlStatLimit" << YAML::Value << config.http.url_stat.limit;
+        emitter << YAML::Key << "UrlStatEnableTrimPath" << YAML::Value << config.http.url_stat.enable_trim_path;
+        emitter << YAML::Key << "UrlStatTrimPathDepth" << YAML::Value << config.http.url_stat.trim_path_depth;
+        emitter << YAML::Key << "UrlStatMethodPrefix" << YAML::Value << config.http.url_stat.method_prefix;
 
         emitter << YAML::Key << "Server";
         emitter << YAML::BeginMap;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT GTest_FOUND)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        v1.15.2
+    GIT_TAG        v1.17.0
   )
   # For Windows: Prevent overriding the parent project's compiler/linker settings
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
## Summary

- **Fix API example errors**: `SetSqlQuery()` missing required 2nd parameter in quick_start.md, invalid sampling type `"COUNTING"` → `"COUNTER"` across all docs
- **Fix config key mismatches**: `UrlStatPathDepth` → `UrlStatTrimPathDepth`, add missing `UrlStatEnableTrimPath` option, fix serialization output keys (`ContThroughput` → `ContinueThroughput`, UrlStat nested keys → flat keys)
- **Fix stale references**: Non-existent example files (`web_demo.cpp`, `db_demo.cpp`) → actual files (`http_server.cpp`, `tutorial.cpp`), CMake minimum version `3.14` → `3.20`
- **Align dependency versions**: CMake FetchContent versions now match MODULE.bazel (gRPC 1.63.1, fmt 11.1.4, GoogleTest 1.17.0)
- **Document helper APIs**: Add `helper::ScopedSpanEvent` RAII class and `TraceHttpServer/Client*` convenience functions to instrument.md
