### PR TITLE
[#9] Add pure-C API (tracer_c.h) for C/C++ mixed-library support

### DIFF
--- a/3rd_party/BUILD
+++ b/3rd_party/BUILD
@@ -13,8 +13,9 @@ cc_library(
 
 cc_library(
     name = "httplib",
-    srcs = [
+    hdrs = [
         "httplib.h",
     ],
+    includes = ["."],
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,6 +39,7 @@ cc_library(
     srcs = glob(["src/*.cpp", "src/*.h"]),
     hdrs = [
         "include/pinpoint/tracer.h",
+        "include/pinpoint/tracer_c.h",
     ],
     includes = [
         "3rd_party",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,7 @@ set(SRCS src/agent.cpp
          src/cache.cpp
          src/utility.cpp
          src/sql.cpp
+         src/tracer_c.cpp
          3rd_party/MurmurHash3.cpp)
 
 if (BUILD_SHARED_LIBS)

--- a/example/BUILD
+++ b/example/BUILD
@@ -37,11 +37,47 @@ cc_binary(
     ],
 )
 
+# Pure-C wrapper around cpp-httplib used by the C-only examples.
+# Built as C++ internally; exposes a pure-C header.
+cc_library(
+    name = "httplib_c",
+    srcs = ["httplib_c.cpp"],
+    hdrs = ["httplib_c.h"],
+    includes = ["."],
+    deps = [
+        "//3rd_party:httplib",
+    ],
+)
+
+# HTTP Server example (C port)
+cc_binary(
+    name = "http_server_c",
+    srcs = ["http_server_c.c"],
+    tags = ["examples"],
+    deps = [
+        ":httplib_c",
+        "//:pinpoint-cpp",
+    ],
+)
+
+# Tutorial example (C port)
+cc_binary(
+    name = "tutorial_c",
+    srcs = ["tutorial_c.c"],
+    tags = ["examples"],
+    deps = [
+        ":httplib_c",
+        "//:pinpoint-cpp",
+    ],
+)
+
 # Example suite (buildable without external dependencies)
 filegroup(
     name = "all_examples",
     srcs = [
         ":http_server",
+        ":http_server_c",
         ":tutorial",
+        ":tutorial_c",
     ],
 )

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -9,3 +9,13 @@ target_link_libraries(tutorial ${PINPOINT_CPP_LIBRARY})
 
 add_executable(http_server http_server.cpp)
 target_link_libraries(http_server ${PINPOINT_CPP_LIBRARY})
+
+# C-only port of http_server using the pure-C tracer API (tracer_c.h) and a
+# thin C++ wrapper around cpp-httplib (httplib_c.h / httplib_c.cpp).
+add_executable(http_server_c http_server_c.c httplib_c.cpp)
+target_link_libraries(http_server_c ${PINPOINT_CPP_LIBRARY})
+set_source_files_properties(http_server_c.c PROPERTIES LANGUAGE C)
+set_target_properties(http_server_c PROPERTIES
+    C_STANDARD 11
+    C_STANDARD_REQUIRED ON
+)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -10,12 +10,20 @@ target_link_libraries(tutorial ${PINPOINT_CPP_LIBRARY})
 add_executable(http_server http_server.cpp)
 target_link_libraries(http_server ${PINPOINT_CPP_LIBRARY})
 
-# C-only port of http_server using the pure-C tracer API (tracer_c.h) and a
-# thin C++ wrapper around cpp-httplib (httplib_c.h / httplib_c.cpp).
+# C-only ports using the pure-C tracer API (tracer_c.h) and a thin C++
+# wrapper around cpp-httplib (httplib_c.h / httplib_c.cpp).
 add_executable(http_server_c http_server_c.c httplib_c.cpp)
 target_link_libraries(http_server_c ${PINPOINT_CPP_LIBRARY})
 set_source_files_properties(http_server_c.c PROPERTIES LANGUAGE C)
 set_target_properties(http_server_c PROPERTIES
+    C_STANDARD 11
+    C_STANDARD_REQUIRED ON
+)
+
+add_executable(tutorial_c tutorial_c.c httplib_c.cpp)
+target_link_libraries(tutorial_c ${PINPOINT_CPP_LIBRARY})
+set_source_files_properties(tutorial_c.c PROPERTIES LANGUAGE C)
+set_target_properties(tutorial_c PROPERTIES
     C_STANDARD 11
     C_STANDARD_REQUIRED ON
 )

--- a/example/http_server_c.c
+++ b/example/http_server_c.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2020-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file http_server_c.c
+ * @brief Pure-C port of example/http_server.cpp.
+ *
+ * Demonstrates how to combine the Pinpoint C API (pinpoint/tracer_c.h) with
+ * a thin C wrapper around cpp-httplib (httplib_c.h) to trace an HTTP server
+ * from plain C code.  The behaviour mirrors the C++ example exactly:
+ *
+ *   1. Create an agent and start the HTTP server listening on 0.0.0.0:8090.
+ *   2. For each GET /foo request, open a root span, extract the inbound
+ *      trace context from the request headers, record the request, emit
+ *      some nested span events with randomised sleeps, then finalize.
+ *
+ * Build: compiled as C (-x c).  Links against pinpoint_cpp-static and
+ * the httplib_c wrapper object.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#if defined(_WIN32)
+#  include <windows.h>
+#  define sleep_ms(ms) Sleep((DWORD)(ms))
+#else
+#  include <unistd.h>
+#  define sleep_ms(ms) usleep((useconds_t)((ms) * 1000))
+#endif
+
+#include "pinpoint/tracer_c.h"
+#include "httplib_c.h"
+
+/* ========================================================================== */
+/* Randomised sample data — matches the C++ example                            */
+/* ========================================================================== */
+
+static const int kHttpStatus[5] = {200, 303, 404, 500, 501};
+
+static const char* const kUrls[5] = {
+    "/path/to?resource=here",
+    "/example/to?resource=here",
+    "/pinpoint",
+    "/pinpoint-apm/pinpoint",
+    "/pinpoint-envoy/to?resource=here",
+};
+
+static const char* const kMethods[5] = { "GET", "PUT", "DELETE", "GET", "PUT" };
+
+static const int kSleepMillis[5] = {5, 10, 50, 80, 100};
+
+static int random_number(void) {
+    return rand() % 5;
+}
+
+/* ========================================================================== */
+/* Helpers                                                                      */
+/* ========================================================================== */
+
+/**
+ * Opens a root span for an inbound HTTP request.  Extracts any incoming
+ * Pinpoint trace-context headers from the request so that cross-process
+ * traces are linked.
+ */
+static pt_span_t make_span(const hlc_request_t* req) {
+    pt_agent_t agent = pt_global_agent();
+
+    /* Build a pt_header_reader_t directly from the httplib header map — the
+     * hlc_headers_get/hlc_headers_for_each signatures match pt_reader_get_fn
+     * and pt_header_for_each_fn exactly, so no adapter code is needed. */
+    pt_header_reader_t reader;
+    reader.userdata = hlc_request_headers_handle(req);
+    reader.get      = hlc_headers_get;
+    reader.for_each = hlc_headers_for_each;
+
+    /* NewSpan expects a pt_context_reader_t (smaller, read-only subset of
+     * pt_header_reader_t).  Build one from the same backing data. */
+    pt_context_reader_t ctx_reader;
+    ctx_reader.userdata = reader.userdata;
+    ctx_reader.get      = reader.get;
+
+    pt_span_t span = pt_agent_new_span_with_reader(
+        agent, "C Http Server", hlc_request_path(req), &ctx_reader);
+
+    /* Compute endpoint: prefer the "Host" header, else fall back to local_addr:port. */
+    char endpoint[512];
+    const char* host = hlc_request_get_header(req, "Host");
+    if (host && host[0] != '\0') {
+        snprintf(endpoint, sizeof(endpoint), "%s", host);
+    } else {
+        snprintf(endpoint, sizeof(endpoint), "%s:%d",
+                 hlc_request_local_addr(req), hlc_request_local_port(req));
+    }
+
+    pt_trace_http_server_request(span,
+                                 hlc_request_remote_addr(req),
+                                 endpoint,
+                                 &reader);
+
+    /* Release the non-owning handle returned by pt_global_agent(). */
+    pt_agent_destroy(agent);
+
+    return span;
+}
+
+/**
+ * Creates a nested cascade of span events exactly like the C++ example.
+ * Each "New" pushes an event, and the matching "End" pops it.
+ */
+static void record_nested_events(pt_span_t span) {
+    const int rand_url    = random_number();
+    const int rand_method = random_number();
+    const int rand_status = random_number();
+
+    pt_span_event_t e;
+
+    e = pt_span_new_event(span, "func_example");
+    sleep_ms(kSleepMillis[random_number()]);
+    pt_span_event_destroy(e);
+
+    e = pt_span_new_event(span, "func_1");
+    sleep_ms(kSleepMillis[random_number()]);
+    pt_span_event_destroy(e);
+
+    e = pt_span_new_event(span, "func_2");
+    sleep_ms(kSleepMillis[random_number()]);
+    pt_span_end_event(span);
+    pt_span_event_destroy(e);
+
+    e = pt_span_new_event(span, "func_3");
+    sleep_ms(kSleepMillis[random_number()]);
+    pt_span_event_destroy(e);
+
+    e = pt_span_new_event(span, "func_4");
+    sleep_ms(kSleepMillis[random_number()]);
+    pt_span_event_destroy(e);
+
+    e = pt_span_new_event(span, "func_5");
+    sleep_ms(kSleepMillis[random_number()]);
+    pt_span_end_event(span);
+    pt_span_event_destroy(e);
+
+    pt_span_end_event(span);  /* closes func_4 */
+    pt_span_end_event(span);  /* closes func_3 */
+
+    e = pt_span_new_event(span, "foo");
+    sleep_ms(kSleepMillis[random_number()]);
+    pt_span_event_destroy(e);
+
+    e = pt_span_new_event(span, "bar");
+    sleep_ms(kSleepMillis[random_number()]);
+    pt_span_end_event(span);
+    pt_span_event_destroy(e);
+
+    pt_span_end_event(span);  /* closes foo  */
+
+    pt_span_end_event(span);  /* closes func_1 */
+    pt_span_end_event(span);  /* closes func_example */
+
+    const int status_code = kHttpStatus[rand_status];
+    pt_span_set_status_code(span, status_code);
+    pt_span_set_url_stat(span, kUrls[rand_url], kMethods[rand_method], status_code);
+}
+
+/* ========================================================================== */
+/* Handler: GET /foo                                                            */
+/* ========================================================================== */
+
+static void on_foo(const hlc_request_t* req, hlc_response_t* res, void* ud) {
+    (void)ud;
+
+    pt_span_t span = make_span(req);
+
+    pt_span_event_t foo_event = pt_span_new_event(span, "foo");
+
+    /* Simulate some work (10–500 ms). */
+    sleep_ms(10 + (rand() % 491));
+
+    hlc_response_set_content(res, "hello, foo!!", "text/plain");
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(foo_event);
+
+    /* Record response headers on the span. */
+    pt_header_reader_t resp_reader;
+    resp_reader.userdata = hlc_response_headers_handle(res);
+    resp_reader.get      = hlc_headers_get;
+    resp_reader.for_each = hlc_headers_for_each;
+    pt_span_record_header(span, PT_HTTP_RESPONSE, &resp_reader);
+
+    record_nested_events(span);
+
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+/* ========================================================================== */
+/* Entry point                                                                  */
+/* ========================================================================== */
+
+int main(void) {
+    /* Seed RNG for deterministic-enough demo data. */
+    srand((unsigned)time(NULL));
+
+    /* setenv() with overwrite=0 matches the C++ example: only set if unset. */
+    setenv("PINPOINT_CPP_CONFIG_FILE",        "/tmp/pinpoint-config.yaml", 0);
+    setenv("PINPOINT_CPP_APPLICATION_NAME",   "c-http-server",             0);
+    setenv("PINPOINT_CPP_HTTP_COLLECT_URL_STAT", "true",                   0);
+    /* setenv("PINPOINT_CPP_LOG_LEVEL", "debug", 0); */
+
+    pt_agent_t agent = pt_create_agent();
+    if (!agent) {
+        fprintf(stderr, "failed to create pinpoint agent\n");
+        return 1;
+    }
+
+    hlc_server_t server = hlc_server_create();
+    if (!server) {
+        fprintf(stderr, "failed to create http server\n");
+        pt_agent_shutdown(agent);
+        pt_agent_destroy(agent);
+        return 1;
+    }
+
+    hlc_server_get(server, "/foo", on_foo, NULL);
+
+    printf("c-http-server listening on 0.0.0.0:8090\n");
+    (void)hlc_server_listen(server, "0.0.0.0", 8090);
+
+    hlc_server_destroy(server);
+    pt_agent_shutdown(agent);
+    pt_agent_destroy(agent);
+
+    return 0;
+}

--- a/example/httplib_c.cpp
+++ b/example/httplib_c.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file httplib_c.cpp
+ * @brief C++ implementation of the pure-C httplib wrapper declared in
+ *        httplib_c.h.
+ *
+ * Handles are thin heap-allocated wrappers around httplib objects.  Request
+ * and response wrapper instances are built on the stack inside the handler
+ * dispatch lambda — they live exactly as long as the handler call.
+ */
+
+#include "httplib_c.h"
+#include "httplib.h"
+
+#include <string>
+
+// ============================================================================
+// Opaque handle definitions
+// ============================================================================
+
+struct hlc_server_s {
+    httplib::Server server;
+};
+
+struct hlc_request_s {
+    const httplib::Request* req;
+};
+
+struct hlc_response_s {
+    httplib::Response* res;
+};
+
+// ============================================================================
+// Server lifecycle
+// ============================================================================
+
+extern "C" hlc_server_t hlc_server_create(void) {
+    return new hlc_server_s();
+}
+
+extern "C" void hlc_server_destroy(hlc_server_t server) {
+    delete server;
+}
+
+extern "C" void hlc_server_get(hlc_server_t   server,
+                               const char*    pattern,
+                               hlc_handler_fn handler,
+                               void*          userdata) {
+    if (!server || !pattern || !handler) return;
+
+    // Capture the C handler pair by value; the lambda is invoked for each
+    // matching request on one of httplib's worker threads.
+    server->server.Get(pattern,
+        [handler, userdata](const httplib::Request& req, httplib::Response& res) {
+            hlc_request_s  c_req{&req};
+            hlc_response_s c_res{&res};
+            handler(&c_req, &c_res, userdata);
+        });
+}
+
+extern "C" int hlc_server_listen(hlc_server_t server, const char* host, int port) {
+    if (!server || !host) return 0;
+    return server->server.listen(host, port) ? 1 : 0;
+}
+
+extern "C" void hlc_server_stop(hlc_server_t server) {
+    if (server) server->server.stop();
+}
+
+// ============================================================================
+// Request accessors
+// ============================================================================
+
+extern "C" const char* hlc_request_path(const hlc_request_t* req) {
+    return (req && req->req) ? req->req->path.c_str() : "";
+}
+
+extern "C" const char* hlc_request_method(const hlc_request_t* req) {
+    return (req && req->req) ? req->req->method.c_str() : "";
+}
+
+extern "C" const char* hlc_request_remote_addr(const hlc_request_t* req) {
+    return (req && req->req) ? req->req->remote_addr.c_str() : "";
+}
+
+extern "C" const char* hlc_request_local_addr(const hlc_request_t* req) {
+    return (req && req->req) ? req->req->local_addr.c_str() : "";
+}
+
+extern "C" int hlc_request_local_port(const hlc_request_t* req) {
+    return (req && req->req) ? req->req->local_port : 0;
+}
+
+extern "C" const char* hlc_request_get_header(const hlc_request_t* req,
+                                              const char*          key) {
+    if (!req || !req->req || !key) return nullptr;
+    auto it = req->req->headers.find(key);
+    return it == req->req->headers.end() ? nullptr : it->second.c_str();
+}
+
+extern "C" void* hlc_request_headers_handle(const hlc_request_t* req) {
+    if (!req || !req->req) return nullptr;
+    // httplib::Headers is std::multimap<std::string, std::string, ...>
+    // We return a non-owning pointer; lifetime is tied to the request.
+    return const_cast<httplib::Headers*>(&req->req->headers);
+}
+
+// ============================================================================
+// Response setters
+// ============================================================================
+
+extern "C" void hlc_response_set_content(hlc_response_t* res,
+                                         const char*     content,
+                                         const char*     mime_type) {
+    if (!res || !res->res || !content) return;
+    res->res->set_content(content, mime_type ? mime_type : "text/plain");
+}
+
+extern "C" void hlc_response_set_status(hlc_response_t* res, int status) {
+    if (res && res->res) res->res->status = status;
+}
+
+extern "C" void hlc_response_set_header(hlc_response_t* res,
+                                        const char*     key,
+                                        const char*     value) {
+    if (!res || !res->res || !key || !value) return;
+    res->res->set_header(key, value);
+}
+
+extern "C" void* hlc_response_headers_handle(const hlc_response_t* res) {
+    if (!res || !res->res) return nullptr;
+    return &res->res->headers;
+}
+
+// ============================================================================
+// Header map access
+// ============================================================================
+
+extern "C" const char* hlc_headers_get(void* handle, const char* key) {
+    if (!handle || !key) return nullptr;
+    const auto* headers = static_cast<const httplib::Headers*>(handle);
+    auto it = headers->find(key);
+    return it == headers->end() ? nullptr : it->second.c_str();
+}
+
+extern "C" void hlc_headers_for_each(void*                 handle,
+                                     hlc_header_foreach_cb callback,
+                                     void*                 callback_userdata) {
+    if (!handle || !callback) return;
+    const auto* headers = static_cast<const httplib::Headers*>(handle);
+    for (const auto& kv : *headers) {
+        if (callback(kv.first.c_str(), kv.second.c_str(), callback_userdata) != 0) break;
+    }
+}

--- a/example/httplib_c.cpp
+++ b/example/httplib_c.cpp
@@ -45,6 +45,26 @@ struct hlc_response_s {
     httplib::Response* res;
 };
 
+struct hlc_client_s {
+    httplib::Client cli;
+    explicit hlc_client_s(const std::string& host) : cli(host) {}
+};
+
+struct hlc_mutable_headers_s {
+    httplib::Headers headers;
+};
+
+// Holds either a successful httplib::Result or a plain error message.
+struct hlc_result_s {
+    httplib::Result     result;
+    std::string         error_msg;
+    explicit hlc_result_s(httplib::Result r) : result(std::move(r)) {
+        if (!result) {
+            error_msg = httplib::to_string(result.error());
+        }
+    }
+};
+
 // ============================================================================
 // Server lifecycle
 // ============================================================================
@@ -104,6 +124,10 @@ extern "C" const char* hlc_request_local_addr(const hlc_request_t* req) {
 
 extern "C" int hlc_request_local_port(const hlc_request_t* req) {
     return (req && req->req) ? req->req->local_port : 0;
+}
+
+extern "C" const char* hlc_request_body(const hlc_request_t* req) {
+    return (req && req->req) ? req->req->body.c_str() : "";
 }
 
 extern "C" const char* hlc_request_get_header(const hlc_request_t* req,
@@ -166,4 +190,76 @@ extern "C" void hlc_headers_for_each(void*                 handle,
     for (const auto& kv : *headers) {
         if (callback(kv.first.c_str(), kv.second.c_str(), callback_userdata) != 0) break;
     }
+}
+
+extern "C" void hlc_headers_set(void* handle, const char* key, const char* value) {
+    if (!handle || !key || !value) return;
+    auto* headers = static_cast<httplib::Headers*>(handle);
+    headers->emplace(key, value);
+}
+
+// ============================================================================
+// Mutable headers
+// ============================================================================
+
+extern "C" hlc_mutable_headers_t hlc_mutable_headers_create(void) {
+    return new hlc_mutable_headers_s();
+}
+
+extern "C" void hlc_mutable_headers_destroy(hlc_mutable_headers_t headers) {
+    delete headers;
+}
+
+extern "C" void* hlc_mutable_headers_handle(hlc_mutable_headers_t headers) {
+    return headers ? &headers->headers : nullptr;
+}
+
+// ============================================================================
+// HTTP client
+// ============================================================================
+
+extern "C" hlc_client_t hlc_client_create(const char* host) {
+    if (!host) return nullptr;
+    return new hlc_client_s(host);
+}
+
+extern "C" void hlc_client_destroy(hlc_client_t client) {
+    delete client;
+}
+
+extern "C" hlc_result_t hlc_client_get(hlc_client_t client,
+                                       const char*  path,
+                                       void*        headers) {
+    if (!client || !path) return nullptr;
+    httplib::Result result = headers
+        ? client->cli.Get(path, *static_cast<httplib::Headers*>(headers))
+        : client->cli.Get(path);
+    return new hlc_result_s(std::move(result));
+}
+
+extern "C" int hlc_result_ok(const hlc_result_t result) {
+    return (result && static_cast<bool>(result->result)) ? 1 : 0;
+}
+
+extern "C" int hlc_result_status(const hlc_result_t result) {
+    return (result && result->result) ? result->result->status : 0;
+}
+
+extern "C" const char* hlc_result_body(const hlc_result_t result) {
+    return (result && result->result) ? result->result->body.c_str() : "";
+}
+
+extern "C" void* hlc_result_headers_handle(const hlc_result_t result) {
+    if (!result || !result->result) return nullptr;
+    // Cast away the logical const — the pointer is treated as read-only by
+    // the C header accessors (hlc_headers_get / hlc_headers_for_each).
+    return const_cast<httplib::Headers*>(&result->result->headers);
+}
+
+extern "C" const char* hlc_result_error_message(const hlc_result_t result) {
+    return result ? result->error_msg.c_str() : "";
+}
+
+extern "C" void hlc_result_destroy(hlc_result_t result) {
+    delete result;
 }

--- a/example/httplib_c.h
+++ b/example/httplib_c.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2020-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file httplib_c.h
+ * @brief Pure-C wrapper around the cpp-httplib HTTP server.
+ *
+ * This header exposes a small subset of httplib::Server's functionality to C
+ * callers using opaque handles and plain function pointers.  The header-only
+ * httplib.h itself is C++-only, so this wrapper is the bridge that makes it
+ * usable from C programs.
+ *
+ * The accessor functions that expose headers — hlc_headers_get() and
+ * hlc_headers_for_each() — use exactly the same signatures expected by
+ * pt_reader_get_fn and pt_header_for_each_fn in pinpoint/tracer_c.h, so a
+ * pt_header_reader_t can be built directly from an hlc_request_t without
+ * writing adapter functions:
+ *
+ * @code
+ *   pt_header_reader_t reader = {
+ *       hlc_request_headers_handle(req),
+ *       hlc_headers_get,
+ *       hlc_headers_for_each,
+ *   };
+ * @endcode
+ */
+
+#ifndef PINPOINT_EXAMPLE_HTTPLIB_C_H
+#define PINPOINT_EXAMPLE_HTTPLIB_C_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ========================================================================== */
+/* Opaque handles                                                               */
+/* ========================================================================== */
+
+/** Opaque handle to a cpp-httplib server instance. */
+typedef struct hlc_server_s*  hlc_server_t;
+
+/** Opaque view of a single HTTP request.  Valid only during a handler call. */
+typedef struct hlc_request_s  hlc_request_t;
+
+/** Opaque view of a single HTTP response.  Valid only during a handler call. */
+typedef struct hlc_response_s hlc_response_t;
+
+/* ========================================================================== */
+/* Handler callback                                                             */
+/* ========================================================================== */
+
+/**
+ * @brief Per-request handler callback.
+ *
+ * The @p req and @p res pointers are only valid for the duration of this
+ * call — do not store them.
+ */
+typedef void (*hlc_handler_fn)(const hlc_request_t* req,
+                               hlc_response_t*       res,
+                               void*                 userdata);
+
+/* ========================================================================== */
+/* Server lifecycle                                                             */
+/* ========================================================================== */
+
+/** Creates a new HTTP server.  Free with hlc_server_destroy(). */
+hlc_server_t hlc_server_create(void);
+
+/** Releases a server created by hlc_server_create(). */
+void hlc_server_destroy(hlc_server_t server);
+
+/**
+ * @brief Registers a handler for the GET method on @p pattern.
+ *
+ * @param pattern  httplib path pattern (e.g. "/foo").
+ * @param handler  Callback invoked on match.
+ * @param userdata Opaque pointer forwarded to @p handler.
+ */
+void hlc_server_get(hlc_server_t   server,
+                    const char*    pattern,
+                    hlc_handler_fn handler,
+                    void*          userdata);
+
+/**
+ * @brief Blocks until the server is stopped or listen fails.
+ *
+ * @return 1 if listen() succeeded, 0 on failure.
+ */
+int hlc_server_listen(hlc_server_t server, const char* host, int port);
+
+/** Requests that the server stop accepting connections. */
+void hlc_server_stop(hlc_server_t server);
+
+/* ========================================================================== */
+/* Request accessors                                                            */
+/* ========================================================================== */
+
+/** Returns the request path (e.g. "/foo"), NUL-terminated. */
+const char* hlc_request_path(const hlc_request_t* req);
+
+/** Returns the HTTP method (e.g. "GET"), NUL-terminated. */
+const char* hlc_request_method(const hlc_request_t* req);
+
+/** Returns the remote peer address. */
+const char* hlc_request_remote_addr(const hlc_request_t* req);
+
+/** Returns the local (server-side) address. */
+const char* hlc_request_local_addr(const hlc_request_t* req);
+
+/** Returns the local (server-side) port. */
+int hlc_request_local_port(const hlc_request_t* req);
+
+/**
+ * @brief Looks up a request header by name.
+ *
+ * @return Pointer to the value, or NULL if absent.  The pointer is valid
+ *         for the lifetime of the request (i.e. during the handler call).
+ */
+const char* hlc_request_get_header(const hlc_request_t* req, const char* key);
+
+/**
+ * @brief Returns an opaque handle suitable for hlc_headers_get() /
+ *        hlc_headers_for_each(), or for use as the userdata field of a
+ *        pt_header_reader_t.
+ */
+void* hlc_request_headers_handle(const hlc_request_t* req);
+
+/* ========================================================================== */
+/* Response setters                                                             */
+/* ========================================================================== */
+
+/** Sets the response body and its Content-Type. */
+void hlc_response_set_content(hlc_response_t* res,
+                              const char*     content,
+                              const char*     mime_type);
+
+/** Sets the HTTP response status code. */
+void hlc_response_set_status(hlc_response_t* res, int status);
+
+/** Adds (or replaces) a response header. */
+void hlc_response_set_header(hlc_response_t* res,
+                             const char*     key,
+                             const char*     value);
+
+/**
+ * @brief Returns an opaque handle for the response header map.
+ *
+ * Usable with hlc_headers_get() / hlc_headers_for_each() or as the userdata
+ * field of a pt_header_reader_t.
+ */
+void* hlc_response_headers_handle(const hlc_response_t* res);
+
+/* ========================================================================== */
+/* Header map access — signatures chosen to be directly compatible with        */
+/* pt_reader_get_fn and pt_header_for_each_fn from pinpoint/tracer_c.h.        */
+/* ========================================================================== */
+
+/**
+ * @brief Iteration callback for hlc_headers_for_each().
+ *
+ * @return 0 to continue iteration, non-zero to stop early.
+ */
+typedef int (*hlc_header_foreach_cb)(const char* key,
+                                     const char* value,
+                                     void*       userdata);
+
+/**
+ * @brief Looks up a value by key in a headers map.
+ *
+ * @param handle  Handle obtained from hlc_request_headers_handle() or
+ *                hlc_response_headers_handle().
+ * @return        Value pointer, or NULL if the key is absent.  The pointer
+ *                remains valid as long as the underlying request/response
+ *                object is alive.
+ */
+const char* hlc_headers_get(void* handle, const char* key);
+
+/**
+ * @brief Iterates all entries in a headers map.
+ *
+ * @param handle          Handle obtained from hlc_request_headers_handle() or
+ *                        hlc_response_headers_handle().
+ * @param callback        Per-entry callback.
+ * @param callback_userdata  Opaque pointer forwarded to @p callback.
+ */
+void hlc_headers_for_each(void*                  handle,
+                          hlc_header_foreach_cb  callback,
+                          void*                  callback_userdata);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PINPOINT_EXAMPLE_HTTPLIB_C_H */

--- a/example/httplib_c.h
+++ b/example/httplib_c.h
@@ -58,6 +58,15 @@ typedef struct hlc_request_s  hlc_request_t;
 /** Opaque view of a single HTTP response.  Valid only during a handler call. */
 typedef struct hlc_response_s hlc_response_t;
 
+/** Opaque HTTP client. */
+typedef struct hlc_client_s*          hlc_client_t;
+
+/** Opaque heap-allocated headers map (used for outbound requests). */
+typedef struct hlc_mutable_headers_s* hlc_mutable_headers_t;
+
+/** Opaque HTTP client result (success or error). */
+typedef struct hlc_result_s*          hlc_result_t;
+
 /* ========================================================================== */
 /* Handler callback                                                             */
 /* ========================================================================== */
@@ -122,6 +131,9 @@ const char* hlc_request_local_addr(const hlc_request_t* req);
 
 /** Returns the local (server-side) port. */
 int hlc_request_local_port(const hlc_request_t* req);
+
+/** Returns the request body (NUL-terminated, may contain embedded NULs). */
+const char* hlc_request_body(const hlc_request_t* req);
 
 /**
  * @brief Looks up a request header by name.
@@ -199,6 +211,88 @@ const char* hlc_headers_get(void* handle, const char* key);
 void hlc_headers_for_each(void*                  handle,
                           hlc_header_foreach_cb  callback,
                           void*                  callback_userdata);
+
+/**
+ * @brief Writes (or inserts) a key/value into a header map.
+ *
+ * Signature matches pt_writer_set_fn so it can be used directly as the .set
+ * field of a pt_context_writer_t.
+ *
+ * @param handle  Must be obtained from hlc_mutable_headers_handle() or
+ *                hlc_response_headers_handle().  Passing a request-headers
+ *                handle is undefined behaviour (those are const).
+ */
+void hlc_headers_set(void* handle, const char* key, const char* value);
+
+/* ========================================================================== */
+/* Mutable headers builder (for outbound HTTP client requests)                 */
+/* ========================================================================== */
+
+/** Creates an empty heap-allocated headers map. */
+hlc_mutable_headers_t hlc_mutable_headers_create(void);
+
+/** Releases a mutable headers map. */
+void hlc_mutable_headers_destroy(hlc_mutable_headers_t headers);
+
+/**
+ * @brief Returns an opaque handle compatible with hlc_headers_get(),
+ *        hlc_headers_for_each(), and hlc_headers_set() — and with the
+ *        userdata fields of pt_header_reader_t / pt_context_writer_t.
+ */
+void* hlc_mutable_headers_handle(hlc_mutable_headers_t headers);
+
+/* ========================================================================== */
+/* HTTP client                                                                  */
+/* ========================================================================== */
+
+/**
+ * @brief Creates an HTTP client targeting @p host (e.g. "localhost:8090").
+ *
+ * Free with hlc_client_destroy().
+ */
+hlc_client_t hlc_client_create(const char* host);
+
+/** Releases a client created by hlc_client_create(). */
+void hlc_client_destroy(hlc_client_t client);
+
+/**
+ * @brief Performs a GET request.
+ *
+ * @param client   Client handle.
+ * @param path     Request path (e.g. "/foo").
+ * @param headers  Optional headers handle from hlc_mutable_headers_handle().
+ *                 Pass NULL to send no extra headers.
+ * @return         Result handle; must be released with hlc_result_destroy().
+ *                 Never NULL — use hlc_result_ok() to distinguish success
+ *                 from transport-level failure.
+ */
+hlc_result_t hlc_client_get(hlc_client_t client,
+                            const char*  path,
+                            void*        headers);
+
+/** Non-zero if a response was received; zero on transport failure. */
+int hlc_result_ok(const hlc_result_t result);
+
+/** HTTP status code; meaningful only when hlc_result_ok() returns non-zero. */
+int hlc_result_status(const hlc_result_t result);
+
+/** Response body (NUL-terminated); empty string on error. */
+const char* hlc_result_body(const hlc_result_t result);
+
+/**
+ * @brief Returns an opaque handle over the response headers map.
+ *        Valid only while @p result is alive.  NULL on transport failure.
+ */
+void* hlc_result_headers_handle(const hlc_result_t result);
+
+/**
+ * @brief Returns a human-readable error message, or empty string on success.
+ *        The returned pointer remains valid while @p result is alive.
+ */
+const char* hlc_result_error_message(const hlc_result_t result);
+
+/** Releases a result handle. */
+void hlc_result_destroy(hlc_result_t result);
 
 #ifdef __cplusplus
 }

--- a/example/tutorial_c.c
+++ b/example/tutorial_c.c
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2020-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file tutorial_c.c
+ * @brief Pure-C port of example/tutorial.cpp.
+ *
+ * Exercises the whole Pinpoint C API surface in a single request flow:
+ *
+ *   Inbound  → new span with extracted trace context
+ *            → record request headers on the span
+ *            → open a child span event for an outbound HTTP call
+ *               · set service type / endpoint / destination
+ *               · inject trace context into the outbound headers
+ *               · annotate URL and status code
+ *               · record errors if the call fails
+ *            → open another child span event
+ *               · create an async span for a background thread
+ *               · emit a nested span event on the async span
+ *               · end the async span
+ *            → set status + end span
+ *
+ * The downstream HTTP endpoint this tutorial points at is localhost:8090,
+ * which is exactly what example/http_server_c (or http_server) listens on —
+ * run that alongside this program to see a full two-hop trace.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(_WIN32)
+#  include <windows.h>
+#  define sleep_sec(s) Sleep((DWORD)((s) * 1000))
+#else
+#  include <unistd.h>
+#  define sleep_sec(s) sleep((unsigned)(s))
+#endif
+
+#include "pinpoint/tracer_c.h"
+#include "httplib_c.h"
+
+/* ========================================================================== */
+/* Per-request handler state — forwarded into on_foo() via the userdata ptr    */
+/* ========================================================================== */
+
+typedef struct {
+    pt_agent_t agent;
+} handler_ctx_t;
+
+/* ========================================================================== */
+/* GET /foo — builds a full trace for this request                              */
+/* ========================================================================== */
+
+static void on_foo(const hlc_request_t* req, hlc_response_t* res, void* userdata) {
+    handler_ctx_t* ctx = (handler_ctx_t*)userdata;
+
+    /* ---- 1. Open root span from inbound context ---------------------------- */
+
+    pt_context_reader_t req_ctx_reader = {
+        hlc_request_headers_handle(req),
+        hlc_headers_get,
+    };
+    pt_span_t span = pt_agent_new_span_with_reader(
+        ctx->agent, "C Web Server", "/foo", &req_ctx_reader);
+
+    pt_span_set_remote_address(span, hlc_request_remote_addr(req));
+
+    char endpoint[512];
+    const char* host_hdr = hlc_request_get_header(req, "Host");
+    if (host_hdr && host_hdr[0] != '\0') {
+        snprintf(endpoint, sizeof(endpoint), "%s", host_hdr);
+    } else {
+        snprintf(endpoint, sizeof(endpoint), "%s:%d",
+                 hlc_request_local_addr(req), hlc_request_local_port(req));
+    }
+    pt_span_set_end_point(span, endpoint);
+
+    /* Record inbound request headers on the span. */
+    pt_header_reader_t req_hdr_reader = {
+        hlc_request_headers_handle(req),
+        hlc_headers_get,
+        hlc_headers_for_each,
+    };
+    pt_span_record_header(span, PT_HTTP_REQUEST, &req_hdr_reader);
+
+    /* ---- 2. Outbound HTTP call traced as a child span event ---------------- */
+
+    const char* downstream_host = "localhost:8090";
+
+    pt_span_event_t se = pt_span_new_event(span, "TestSpanEvent");
+    pt_span_event_set_service_type(se, PT_SERVICE_TYPE_CPP_HTTP_CLIENT);
+    pt_span_event_set_end_point(se, downstream_host);
+    pt_span_event_set_destination(se, downstream_host);
+
+    /* Inject our trace context into the outbound headers.  The headers map
+     * is created here and destroyed at the end of the event. */
+    hlc_mutable_headers_t out_headers = hlc_mutable_headers_create();
+    pt_context_writer_t   ctx_writer  = {
+        hlc_mutable_headers_handle(out_headers),
+        hlc_headers_set,
+    };
+    pt_span_inject_context(span, &ctx_writer);
+
+    /* Annotate the outbound URL. */
+    pt_annotation_t anno = pt_span_event_get_annotations(se);
+    pt_annotation_append_string(anno, PT_ANNOTATION_HTTP_URL, "localhost:8090/foo");
+
+    /* Actually issue the GET. */
+    hlc_client_t cli = hlc_client_create(downstream_host);
+    hlc_result_t result = hlc_client_get(cli, "/foo",
+                                         hlc_mutable_headers_handle(out_headers));
+
+    if (hlc_result_ok(result)) {
+        int status = hlc_result_status(result);
+        if (status == 200) {
+            printf("%s\n", hlc_result_body(result));
+        }
+        pt_annotation_append_int(anno, PT_ANNOTATION_HTTP_STATUS_CODE, status);
+    } else {
+        const char* err_msg = hlc_result_error_message(result);
+        printf("HTTP error: %s\n", err_msg);
+        pt_span_event_set_error(se, err_msg);
+        pt_span_set_error(span, "http client error");
+    }
+
+    pt_annotation_destroy(anno);
+    hlc_result_destroy(result);
+    hlc_client_destroy(cli);
+    hlc_mutable_headers_destroy(out_headers);
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(se);
+
+    /* ---- 3. Second event with a nested async span -------------------------- */
+
+    pt_span_event_t se2 = pt_span_new_event(span, "TestSpanEvent2");
+
+    pt_span_t async_span = pt_span_new_async_span(span, "New Thread");
+    pt_span_event_t async_event = pt_span_new_event(async_span, "ThreadSpanEvent");
+    pt_span_end_event(async_span);
+    pt_span_event_destroy(async_event);
+    pt_span_end(async_span);
+    pt_span_destroy(async_span);
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(se2);
+
+    /* ---- 4. Finalise ------------------------------------------------------- */
+
+    pt_span_set_status_code(span, 200);
+    pt_span_end(span);
+    pt_span_destroy(span);
+
+    /* Echo the request body back, like the original tutorial. */
+    hlc_response_set_content(res, hlc_request_body(req), "text/plain");
+}
+
+/* ========================================================================== */
+/* Entry point                                                                  */
+/* ========================================================================== */
+
+int main(void) {
+    setenv("PINPOINT_CPP_CONFIG_FILE",      "/tmp/pinpoint-config.yaml", 0);
+    setenv("PINPOINT_CPP_APPLICATION_NAME", "c-tutorial",                0);
+
+    pt_agent_t agent = pt_create_agent();
+    if (!agent) {
+        fprintf(stderr, "failed to create pinpoint agent\n");
+        return 1;
+    }
+
+    /* Give the agent a moment to come up — matches the C++ tutorial. */
+    sleep_sec(5);
+
+    handler_ctx_t ctx = { agent };
+
+    hlc_server_t server = hlc_server_create();
+    hlc_server_get(server, "/foo", on_foo, &ctx);
+
+    printf("c-tutorial listening on 0.0.0.0:8080\n");
+    (void)hlc_server_listen(server, "0.0.0.0", 8080);
+
+    hlc_server_destroy(server);
+    pt_agent_shutdown(agent);
+    pt_agent_destroy(agent);
+    return 0;
+}

--- a/include/pinpoint/tracer_c.h
+++ b/include/pinpoint/tracer_c.h
@@ -70,9 +70,9 @@ extern "C" {
 #define PT_HEADER_PARENT_SPAN_ID       "Pinpoint-pSpanID"
 #define PT_HEADER_SAMPLED              "Pinpoint-Sampled"
 #define PT_HEADER_FLAG                 "Pinpoint-Flags"
-#define PT_HEADER_PARENT_APT_NAME      "Pinpoint-pAppName"
-#define PT_HEADER_PARENT_APT_TYPE      "Pinpoint-pAppType"
-#define PT_HEADER_PARENT_APT_NAMESPACE "Pinpoint-pAppNamespace"
+#define PT_HEADER_PARENT_APP_NAME      "Pinpoint-pAppName"
+#define PT_HEADER_PARENT_APP_TYPE      "Pinpoint-pAppType"
+#define PT_HEADER_PARENT_APP_NAMESPACE "Pinpoint-pAppNamespace"
 #define PT_HEADER_HOST                 "Pinpoint-Host"
 
 /* ========================================================================== */
@@ -96,8 +96,8 @@ extern "C" {
 
 #define PT_APP_TYPE_CPP                 1300
 #define PT_SERVICE_TYPE_CPP             PT_APP_TYPE_CPP
-#define PT_SERVICE_TYPE_CPT_FUNC        1301
-#define PT_SERVICE_TYPE_CPT_HTTP_CLIENT 9800
+#define PT_SERVICE_TYPE_CPP_FUNC        1301
+#define PT_SERVICE_TYPE_CPP_HTTP_CLIENT 9800
 #define PT_SERVICE_TYPE_ASYNC           100
 
 #define PT_SERVICE_TYPE_MYSQL_QUERY     2101

--- a/include/pinpoint/tracer_c.h
+++ b/include/pinpoint/tracer_c.h
@@ -1,0 +1,773 @@
+/*
+ * Copyright 2020-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file tracer_c.h
+ * @brief Pure-C public API for the Pinpoint C++ agent.
+ *
+ * This header is intentionally free of any C++ constructs so that it can be
+ * included from both C and C++ translation units.  C++ programs may use either
+ * this header or the richer pinpoint/tracer.h interface.
+ *
+ * ## Quick-start (C)
+ * @code
+ *   #include "pinpoint/tracer_c.h"
+ *
+ *   // Optional: load configuration before creating the agent.
+ *   pt_set_config_file_path("/etc/pinpoint/agent.yaml");
+ *
+ *   pt_agent_t agent = pt_create_agent();
+ *
+ *   // --- incoming request ---
+ *   pt_context_reader_t reader = { &my_headers, my_header_get };
+ *   pt_span_t span = pt_agent_new_span_with_reader(agent, "MyService", "/api/v1", &reader);
+ *
+ *   // create a child event
+ *   pt_span_event_t se = pt_span_new_event(span, "db_query");
+ *   pt_span_event_set_service_type(se, PT_SERVICE_TYPE_MYSQL_QUERY);
+ *   pt_annotation_t anno = pt_span_event_get_annotations(se);
+ *   pt_annotation_append_string(anno, PT_ANNOTATION_HTTP_URL, "/api/v1");
+ *   pt_annotation_destroy(anno);
+ *   pt_span_end_event(span);
+ *   pt_span_event_destroy(se);
+ *
+ *   pt_span_end(span);
+ *   pt_span_destroy(span);
+ *
+ *   pt_agent_shutdown(agent);
+ *   pt_agent_destroy(agent);
+ * @endcode
+ */
+
+#ifndef PINPOINT_TRACER_C_H
+#define PINPOINT_TRACER_C_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ========================================================================== */
+/* Propagation header name constants                                            */
+/* ========================================================================== */
+
+#define PT_HEADER_TRACE_ID             "Pinpoint-TraceID"
+#define PT_HEADER_SPAN_ID              "Pinpoint-SpanID"
+#define PT_HEADER_PARENT_SPAN_ID       "Pinpoint-pSpanID"
+#define PT_HEADER_SAMPLED              "Pinpoint-Sampled"
+#define PT_HEADER_FLAG                 "Pinpoint-Flags"
+#define PT_HEADER_PARENT_APT_NAME      "Pinpoint-pAppName"
+#define PT_HEADER_PARENT_APT_TYPE      "Pinpoint-pAppType"
+#define PT_HEADER_PARENT_APT_NAMESPACE "Pinpoint-pAppNamespace"
+#define PT_HEADER_HOST                 "Pinpoint-Host"
+
+/* ========================================================================== */
+/* Annotation key constants                                                     */
+/* ========================================================================== */
+
+#define PT_ANNOTATION_API                   12
+#define PT_ANNOTATION_SQL_ID                20
+#define PT_ANNOTATION_SQL_UID               25
+#define PT_ANNOTATION_EXCEPTION_ID          (-52)
+#define PT_ANNOTATION_HTTP_URL              40
+#define PT_ANNOTATION_HTTP_STATUS_CODE      46
+#define PT_ANNOTATION_HTTP_COOKIE           45
+#define PT_ANNOTATION_HTTP_REQUEST_HEADER   47
+#define PT_ANNOTATION_HTTP_RESPONSE_HEADER  55
+#define PT_ANNOTATION_HTTP_PROXY_HEADER     300
+
+/* ========================================================================== */
+/* Service / application type constants                                         */
+/* ========================================================================== */
+
+#define PT_APP_TYPE_CPP                 1300
+#define PT_SERVICE_TYPE_CPP             PT_APP_TYPE_CPP
+#define PT_SERVICE_TYPE_CPT_FUNC        1301
+#define PT_SERVICE_TYPE_CPT_HTTP_CLIENT 9800
+#define PT_SERVICE_TYPE_ASYNC           100
+
+#define PT_SERVICE_TYPE_MYSQL_QUERY     2101
+#define PT_SERVICE_TYPE_MSSQL_QUERY     2201
+#define PT_SERVICE_TYPE_ORACLE_QUERY    2301
+#define PT_SERVICE_TYPE_PGSQL_QUERY     2501
+#define PT_SERVICE_TYPE_CASSANDRA_QUERY 2601
+#define PT_SERVICE_TYPE_MONGODB_QUERY   2651
+
+#define PT_SERVICE_TYPE_MEMCACHED       8050
+#define PT_SERVICE_TYPE_REDIS           8203
+#define PT_SERVICE_TYPE_KAFKA           8660
+#define PT_SERVICE_TYPE_HBASE           8800
+
+#define PT_SERVICE_TYPE_GRPC_CLIENT     9160
+#define PT_SERVICE_TYPE_GRPC_SERVER     1130
+
+#define PT_API_TYPE_DEFAULT             0
+#define PT_API_TYPE_WEB_REQUEST         100
+#define PT_API_TYPE_INVOCATION          200
+
+#define PT_NONE_ASYNC_ID                0
+
+/* ========================================================================== */
+/* Opaque handle types                                                          */
+/* ========================================================================== */
+
+/** Opaque handle to a Pinpoint agent instance. */
+typedef struct pt_agent_s*      pt_agent_t;
+/** Opaque handle to a distributed trace span. */
+typedef struct pt_span_s*       pt_span_t;
+/** Opaque handle to a span event (child operation). */
+typedef struct pt_span_event_s* pt_span_event_t;
+/** Opaque handle to the annotation container of a span or span event. */
+typedef struct pt_annotation_s* pt_annotation_t;
+
+/* ========================================================================== */
+/* Trace identifier                                                             */
+/* ========================================================================== */
+
+/** Maximum length (including NUL terminator) of the agent-id string. */
+#define PT_AGENT_ID_MAX 256
+
+/**
+ * @brief Distributed trace identifier.
+ *
+ * Mirrors pinpoint::TraceId.  The wire representation is
+ * `"<agent_id>^<start_time>^<sequence>"`.
+ */
+typedef struct {
+    char    agent_id[PT_AGENT_ID_MAX]; /**< NUL-terminated agent identifier. */
+    int64_t start_time;                /**< Agent start time (milliseconds since epoch). */
+    int64_t sequence;                  /**< Per-agent sequence number. */
+} pt_trace_id_t;
+
+/* ========================================================================== */
+/* Header type                                                                  */
+/* ========================================================================== */
+
+/**
+ * @brief Logical header group recorded on spans and span events.
+ *
+ * Mirrors pinpoint::HeaderType.
+ */
+typedef enum {
+    PT_HTTP_REQUEST  = 0, /**< Inbound HTTP request headers. */
+    PT_HTTP_RESPONSE = 1, /**< Outbound HTTP response headers. */
+    PT_HTTP_COOKIE   = 2  /**< HTTP cookie headers. */
+} pt_header_type_t;
+
+/* ========================================================================== */
+/* Propagation carrier callback types                                           */
+/* ========================================================================== */
+
+/**
+ * @brief Look up a value by key in a propagation carrier.
+ *
+ * @param userdata Opaque pointer provided at carrier construction time.
+ * @param key      NUL-terminated, case-sensitive header/key name.
+ * @return         Pointer to the NUL-terminated value, or NULL if absent.
+ *                 The pointer must remain valid until the next call on the same
+ *                 carrier or until the carrier is destroyed.
+ */
+typedef const char* (*pt_reader_get_fn)(void* userdata, const char* key);
+
+/**
+ * @brief Write a key/value pair into a propagation carrier.
+ *
+ * @param userdata Opaque pointer provided at carrier construction time.
+ * @param key      NUL-terminated header/key name.
+ * @param value    NUL-terminated value to set.
+ */
+typedef void (*pt_writer_set_fn)(void* userdata, const char* key, const char* value);
+
+/**
+ * @brief Iteration callback invoked by pt_header_for_each_fn for each header.
+ *
+ * @param key      NUL-terminated header name.
+ * @param value    NUL-terminated header value.
+ * @param userdata Opaque pointer passed through from the for_each call.
+ * @return         0 to continue iteration, non-zero to stop early.
+ */
+typedef int (*pt_header_foreach_cb)(const char* key, const char* value, void* userdata);
+
+/**
+ * @brief Iterate all entries in a header carrier.
+ *
+ * Implementors must call @p callback once for every header, passing
+ * @p callback_userdata through unchanged.  Iteration stops when @p callback
+ * returns non-zero.
+ *
+ * @param userdata          Opaque pointer provided at carrier construction time.
+ * @param callback          Per-entry callback.
+ * @param callback_userdata Opaque pointer forwarded to @p callback.
+ */
+typedef void (*pt_header_for_each_fn)(void* userdata, pt_header_foreach_cb callback,
+                                      void* callback_userdata);
+
+/* ========================================================================== */
+/* Propagation carrier structs                                                  */
+/* ========================================================================== */
+
+/**
+ * @brief Read-only propagation carrier.
+ *
+ * Mirrors pinpoint::TraceContextReader.  Typically backed by an HTTP request's
+ * header map.
+ *
+ * Example:
+ * @code
+ *   const char* my_get(void* ud, const char* key) {
+ *       return http_header_get((HttpHeaders*)ud, key); // NULL if absent
+ *   }
+ *   pt_context_reader_t reader = { &my_headers, my_get };
+ * @endcode
+ */
+typedef struct {
+    void*            userdata; /**< Caller-managed context passed to callbacks. */
+    pt_reader_get_fn get;      /**< Value lookup; must not be NULL. */
+} pt_context_reader_t;
+
+/**
+ * @brief Write-only propagation carrier.
+ *
+ * Mirrors pinpoint::TraceContextWriter.  Typically backed by an HTTP request
+ * builder's header map.
+ *
+ * Example:
+ * @code
+ *   void my_set(void* ud, const char* key, const char* value) {
+ *       http_header_set((HttpHeaders*)ud, key, value);
+ *   }
+ *   pt_context_writer_t writer = { &out_headers, my_set };
+ * @endcode
+ */
+typedef struct {
+    void*            userdata; /**< Caller-managed context passed to callbacks. */
+    pt_writer_set_fn set;      /**< Value setter; must not be NULL. */
+} pt_context_writer_t;
+
+/**
+ * @brief Read-only header carrier with iteration support.
+ *
+ * Mirrors pinpoint::HeaderReader.  Used wherever the library needs to both
+ * look up individual headers and iterate over all of them (e.g. recording
+ * request headers on a span).
+ */
+typedef struct {
+    void*                 userdata;  /**< Caller-managed context passed to callbacks. */
+    pt_reader_get_fn      get;       /**< Value lookup; must not be NULL. */
+    pt_header_for_each_fn for_each;  /**< Full iteration; must not be NULL. */
+} pt_header_reader_t;
+
+/**
+ * @brief Read/write header carrier with iteration support.
+ *
+ * Mirrors pinpoint::HeaderReaderWriter.  Convenience type for situations where
+ * a single carrier supports both reading and writing (e.g. an in-place header
+ * map used for context propagation).
+ *
+ * To pass this carrier to a function that accepts pt_context_writer_t, build a
+ * separate pt_context_writer_t with the same userdata and set callback.
+ */
+typedef struct {
+    void*                 userdata;  /**< Caller-managed context passed to callbacks. */
+    pt_reader_get_fn      get;       /**< Value lookup; must not be NULL. */
+    pt_header_for_each_fn for_each;  /**< Full iteration; must not be NULL. */
+    pt_writer_set_fn      set;       /**< Value setter; must not be NULL. */
+} pt_header_reader_writer_t;
+
+/* ========================================================================== */
+/* Call stack reader                                                            */
+/* ========================================================================== */
+
+/**
+ * @brief Per-frame callback invoked during call stack iteration.
+ *
+ * @param module    NUL-terminated module/library name (may be empty, never NULL).
+ * @param function  NUL-terminated function/symbol name.
+ * @param file      NUL-terminated source file path (may be empty, never NULL).
+ * @param line      Source line number (0 if unavailable).
+ * @param userdata  Opaque pointer passed through from the for_each call.
+ */
+typedef void (*pt_callstack_frame_cb)(const char* module, const char* function,
+                                      const char* file, int line, void* userdata);
+
+/**
+ * @brief Call stack provider passed to error-recording functions.
+ *
+ * Mirrors pinpoint::CallStackReader.
+ */
+typedef struct {
+    void* userdata; /**< Caller-managed context passed to callbacks. */
+    /** Iterate all frames, invoking @p callback for each. */
+    void (*for_each)(void* userdata, pt_callstack_frame_cb callback, void* callback_userdata);
+} pt_callstack_reader_t;
+
+/* ========================================================================== */
+/* Global configuration                                                         */
+/* ========================================================================== */
+
+/**
+ * @brief Sets the path of the YAML configuration file.
+ *
+ * Must be called before pt_create_agent() / pt_global_agent().
+ * Mirrors pinpoint::SetConfigFilePath().
+ */
+void pt_set_config_file_path(const char* config_file_path);
+
+/**
+ * @brief Injects a YAML configuration string directly.
+ *
+ * Must be called before pt_create_agent() / pt_global_agent().
+ * Mirrors pinpoint::SetConfigString().
+ */
+void pt_set_config_string(const char* config_string);
+
+/* ========================================================================== */
+/* Agent lifecycle                                                              */
+/* ========================================================================== */
+
+/**
+ * @brief Creates a new Pinpoint agent using the global configuration.
+ *
+ * The returned handle must be released with pt_agent_destroy() after
+ * pt_agent_shutdown() has been called.
+ *
+ * Mirrors pinpoint::CreateAgent().
+ */
+pt_agent_t pt_create_agent(void);
+
+/**
+ * @brief Creates a new Pinpoint agent with an explicit application type.
+ *
+ * @param app_type  Application service-type constant (e.g. PT_APP_TYPE_CPP).
+ *
+ * Mirrors pinpoint::CreateAgent(int32_t).
+ */
+pt_agent_t pt_create_agent_with_type(int32_t app_type);
+
+/**
+ * @brief Returns a handle to the singleton global agent.
+ *
+ * The returned handle must NOT be passed to pt_agent_destroy() — its lifetime
+ * is managed internally.  Returns NULL if no global agent exists.
+ *
+ * Mirrors pinpoint::GlobalAgent().
+ */
+pt_agent_t pt_global_agent(void);
+
+/**
+ * @brief Releases an agent handle created by pt_create_agent() or
+ *        pt_create_agent_with_type().
+ *
+ * @warning Do NOT call this on a handle obtained from pt_global_agent().
+ */
+void pt_agent_destroy(pt_agent_t agent);
+
+/**
+ * @brief Returns non-zero if the agent is enabled and actively sampling.
+ *
+ * Mirrors pinpoint::Agent::Enable().
+ */
+int pt_agent_is_enabled(pt_agent_t agent);
+
+/**
+ * @brief Initiates a graceful shutdown and flushes pending spans.
+ *
+ * Mirrors pinpoint::Agent::Shutdown().
+ */
+void pt_agent_shutdown(pt_agent_t agent);
+
+/* ========================================================================== */
+/* Span creation                                                                */
+/* ========================================================================== */
+
+/**
+ * @brief Creates a new outbound span (no incoming context).
+ *
+ * The returned handle must be released with pt_span_destroy() after
+ * pt_span_end() has been called.
+ *
+ * Mirrors pinpoint::Agent::NewSpan(operation, rpc_point).
+ */
+pt_span_t pt_agent_new_span(pt_agent_t agent, const char* operation, const char* rpc_point);
+
+/**
+ * @brief Creates a new span, extracting context from an inbound carrier.
+ *
+ * @param reader  Inbound propagation carrier (e.g. HTTP request headers).
+ *                May be NULL, in which case no context is extracted.
+ *
+ * Mirrors pinpoint::Agent::NewSpan(operation, rpc_point, reader).
+ */
+pt_span_t pt_agent_new_span_with_reader(pt_agent_t agent, const char* operation,
+                                        const char* rpc_point,
+                                        const pt_context_reader_t* reader);
+
+/**
+ * @brief Creates a new span with an HTTP method and inbound context.
+ *
+ * @param method  NUL-terminated HTTP verb (e.g. "GET", "POST").
+ * @param reader  Inbound propagation carrier.  May be NULL.
+ *
+ * Mirrors pinpoint::Agent::NewSpan(operation, rpc_point, method, reader).
+ */
+pt_span_t pt_agent_new_span_with_method(pt_agent_t agent, const char* operation,
+                                        const char* rpc_point, const char* method,
+                                        const pt_context_reader_t* reader);
+
+/* ========================================================================== */
+/* Span operations                                                              */
+/* ========================================================================== */
+
+/**
+ * @brief Releases a span handle.
+ *
+ * Call pt_span_end() first to flush the span data, then destroy the handle.
+ */
+void pt_span_destroy(pt_span_t span);
+
+/**
+ * @brief Creates a new child span event and pushes it onto the event stack.
+ *
+ * The returned handle must be released with pt_span_event_destroy().
+ * Call pt_span_end_event() on the *span* (not on the event handle) to pop and
+ * finalize the event.
+ *
+ * Mirrors pinpoint::Span::NewSpanEvent(operation).
+ */
+pt_span_event_t pt_span_new_event(pt_span_t span, const char* operation);
+
+/**
+ * @brief Creates a new child span event with an explicit service type.
+ *
+ * Mirrors pinpoint::Span::NewSpanEvent(operation, service_type).
+ */
+pt_span_event_t pt_span_new_event_with_type(pt_span_t span, const char* operation,
+                                            int32_t service_type);
+
+/**
+ * @brief Returns the current (top-of-stack) span event.
+ *
+ * The returned handle must be released with pt_span_event_destroy().
+ * Returns NULL if there is no active event.
+ *
+ * Mirrors pinpoint::Span::GetSpanEvent().
+ */
+pt_span_event_t pt_span_get_event(pt_span_t span);
+
+/**
+ * @brief Pops and finalizes the current span event.
+ *
+ * Records the elapsed time and removes the event from the event stack.
+ * The span event handle obtained from pt_span_new_event() remains valid
+ * after this call but should be released with pt_span_event_destroy().
+ *
+ * Mirrors pinpoint::Span::EndSpanEvent().
+ */
+void pt_span_end_event(pt_span_t span);
+
+/**
+ * @brief Completes the span and flushes all recorded data to the collector.
+ *
+ * Mirrors pinpoint::Span::EndSpan().
+ */
+void pt_span_end(pt_span_t span);
+
+/**
+ * @brief Creates an asynchronous child span for background operations.
+ *
+ * The returned handle must be released with pt_span_destroy().
+ *
+ * Mirrors pinpoint::Span::NewAsyncSpan(async_operation).
+ */
+pt_span_t pt_span_new_async_span(pt_span_t span, const char* async_operation);
+
+/**
+ * @brief Injects the current span context into an outbound carrier.
+ *
+ * Mirrors pinpoint::Span::InjectContext(writer).
+ */
+void pt_span_inject_context(pt_span_t span, pt_context_writer_t* writer);
+
+/**
+ * @brief Applies trace context from an inbound carrier to the span.
+ *
+ * Mirrors pinpoint::Span::ExtractContext(reader).
+ */
+void pt_span_extract_context(pt_span_t span, const pt_context_reader_t* reader);
+
+/**
+ * @brief Returns the distributed trace identifier for this span.
+ *
+ * The returned structure is a value copy and is valid independently of the
+ * span's lifetime.
+ *
+ * Mirrors pinpoint::Span::GetTraceId().
+ */
+pt_trace_id_t pt_span_get_trace_id(pt_span_t span);
+
+/**
+ * @brief Returns the numeric span identifier.
+ *
+ * Mirrors pinpoint::Span::GetSpanId().
+ */
+int64_t pt_span_get_span_id(pt_span_t span);
+
+/**
+ * @brief Returns non-zero if this span is being sampled.
+ *
+ * Mirrors pinpoint::Span::IsSampled().
+ */
+int pt_span_is_sampled(pt_span_t span);
+
+/** Mirrors pinpoint::Span::SetServiceType(). */
+void pt_span_set_service_type(pt_span_t span, int32_t service_type);
+
+/**
+ * @brief Sets the span start time.
+ *
+ * @param ms_since_epoch  Start time expressed as milliseconds since the Unix
+ *                        epoch (UTC).
+ *
+ * Mirrors pinpoint::Span::SetStartTime().
+ */
+void pt_span_set_start_time_ms(pt_span_t span, int64_t ms_since_epoch);
+
+/** Mirrors pinpoint::Span::SetRemoteAddress(). */
+void pt_span_set_remote_address(pt_span_t span, const char* address);
+
+/** Mirrors pinpoint::Span::SetEndPoint(). */
+void pt_span_set_end_point(pt_span_t span, const char* end_point);
+
+/** Mirrors pinpoint::Span::SetError(error_message). */
+void pt_span_set_error(pt_span_t span, const char* error_message);
+
+/** Mirrors pinpoint::Span::SetError(error_name, error_message). */
+void pt_span_set_error_named(pt_span_t span, const char* error_name,
+                             const char* error_message);
+
+/** Mirrors pinpoint::Span::SetStatusCode(). */
+void pt_span_set_status_code(pt_span_t span, int status_code);
+
+/** Mirrors pinpoint::Span::SetUrlStat(). */
+void pt_span_set_url_stat(pt_span_t span, const char* url_pattern,
+                          const char* method, int status_code);
+
+/** Mirrors pinpoint::Span::SetLogging(). */
+void pt_span_set_logging(pt_span_t span, pt_context_writer_t* writer);
+
+/** Mirrors pinpoint::Span::RecordHeader(). */
+void pt_span_record_header(pt_span_t span, pt_header_type_t which,
+                           const pt_header_reader_t* reader);
+
+/**
+ * @brief Returns the annotation container for this span.
+ *
+ * The returned handle must be released with pt_annotation_destroy() when no
+ * longer needed.
+ *
+ * Mirrors pinpoint::Span::GetAnnotations().
+ */
+pt_annotation_t pt_span_get_annotations(pt_span_t span);
+
+/* ========================================================================== */
+/* SpanEvent operations                                                         */
+/* ========================================================================== */
+
+/**
+ * @brief Releases a span event handle.
+ *
+ * Does NOT end/finalize the event — call pt_span_end_event() on the parent
+ * span first.
+ */
+void pt_span_event_destroy(pt_span_event_t se);
+
+/** Mirrors pinpoint::SpanEvent::SetServiceType(). */
+void pt_span_event_set_service_type(pt_span_event_t se, int32_t service_type);
+
+/** Mirrors pinpoint::SpanEvent::SetOperationName(). */
+void pt_span_event_set_operation_name(pt_span_event_t se, const char* operation);
+
+/**
+ * @brief Sets the span event start time.
+ *
+ * @param ms_since_epoch  Start time as milliseconds since the Unix epoch (UTC).
+ *
+ * Mirrors pinpoint::SpanEvent::SetStartTime().
+ */
+void pt_span_event_set_start_time_ms(pt_span_event_t se, int64_t ms_since_epoch);
+
+/** Mirrors pinpoint::SpanEvent::SetDestination(). */
+void pt_span_event_set_destination(pt_span_event_t se, const char* dest);
+
+/** Mirrors pinpoint::SpanEvent::SetEndPoint(). */
+void pt_span_event_set_end_point(pt_span_event_t se, const char* end_point);
+
+/** Mirrors pinpoint::SpanEvent::SetError(error_message). */
+void pt_span_event_set_error(pt_span_event_t se, const char* error_message);
+
+/** Mirrors pinpoint::SpanEvent::SetError(error_name, error_message). */
+void pt_span_event_set_error_named(pt_span_event_t se, const char* error_name,
+                                   const char* error_message);
+
+/**
+ * @brief Records a named error along with a call stack.
+ *
+ * @param reader  Call stack provider.  May be NULL.
+ *
+ * Mirrors pinpoint::SpanEvent::SetError(error_name, error_message, reader).
+ */
+void pt_span_event_set_error_with_callstack(pt_span_event_t se,
+                                            const char* error_name,
+                                            const char* error_message,
+                                            const pt_callstack_reader_t* reader);
+
+/** Mirrors pinpoint::SpanEvent::SetSqlQuery(). */
+void pt_span_event_set_sql_query(pt_span_event_t se, const char* sql_query,
+                                 const char* args);
+
+/** Mirrors pinpoint::SpanEvent::RecordHeader(). */
+void pt_span_event_record_header(pt_span_event_t se, pt_header_type_t which,
+                                 const pt_header_reader_t* reader);
+
+/**
+ * @brief Returns the annotation container for this span event.
+ *
+ * The returned handle must be released with pt_annotation_destroy().
+ *
+ * Mirrors pinpoint::SpanEvent::GetAnnotations().
+ */
+pt_annotation_t pt_span_event_get_annotations(pt_span_event_t se);
+
+/* ========================================================================== */
+/* Annotation operations                                                        */
+/* ========================================================================== */
+
+/**
+ * @brief Releases an annotation handle obtained from pt_span_get_annotations()
+ *        or pt_span_event_get_annotations().
+ */
+void pt_annotation_destroy(pt_annotation_t anno);
+
+/** Mirrors pinpoint::Annotation::AppendInt(). */
+void pt_annotation_append_int(pt_annotation_t anno, int32_t key, int32_t value);
+
+/** Mirrors pinpoint::Annotation::AppendLong(). */
+void pt_annotation_append_long(pt_annotation_t anno, int32_t key, int64_t value);
+
+/** Mirrors pinpoint::Annotation::AppendString(). */
+void pt_annotation_append_string(pt_annotation_t anno, int32_t key, const char* value);
+
+/** Mirrors pinpoint::Annotation::AppendStringString(). */
+void pt_annotation_append_string_string(pt_annotation_t anno, int32_t key,
+                                        const char* s1, const char* s2);
+
+/** Mirrors pinpoint::Annotation::AppendIntStringString(). */
+void pt_annotation_append_int_string_string(pt_annotation_t anno, int32_t key,
+                                            int i, const char* s1, const char* s2);
+
+/**
+ * @brief Mirrors pinpoint::Annotation::AppendBytesStringString().
+ *
+ * @param uid      Pointer to binary data.
+ * @param uid_len  Length of @p uid in bytes.
+ */
+void pt_annotation_append_bytes_string_string(pt_annotation_t anno, int32_t key,
+                                              const unsigned char* uid, int uid_len,
+                                              const char* s1, const char* s2);
+
+/** Mirrors pinpoint::Annotation::AppendLongIntIntByteByteString(). */
+void pt_annotation_append_long_int_int_byte_byte_string(pt_annotation_t anno, int32_t key,
+                                                        int64_t l,
+                                                        int32_t i1, int32_t i2,
+                                                        int32_t b1, int32_t b2,
+                                                        const char* s);
+
+/* ========================================================================== */
+/* HTTP helper functions                                                        */
+/* ========================================================================== */
+
+/**
+ * @brief Records an HTTP server request on the span.
+ *
+ * Mirrors pinpoint::helper::TraceHttpServerRequest(span, remote_addr, endpoint,
+ *                                                  request_reader).
+ */
+void pt_trace_http_server_request(pt_span_t span,
+                                  const char* remote_addr,
+                                  const char* endpoint,
+                                  const pt_header_reader_t* request_reader);
+
+/**
+ * @brief Records an HTTP server request with cookies on the span.
+ *
+ * Mirrors pinpoint::helper::TraceHttpServerRequest(span, remote_addr, endpoint,
+ *                                                  request_reader, cookie_reader).
+ */
+void pt_trace_http_server_request_with_cookie(pt_span_t span,
+                                              const char* remote_addr,
+                                              const char* endpoint,
+                                              const pt_header_reader_t* request_reader,
+                                              const pt_header_reader_t* cookie_reader);
+
+/**
+ * @brief Records an HTTP server response on the span.
+ *
+ * Mirrors pinpoint::helper::TraceHttpServerResponse().
+ */
+void pt_trace_http_server_response(pt_span_t span,
+                                   const char* url_pattern,
+                                   const char* method,
+                                   int status_code,
+                                   const pt_header_reader_t* response_reader);
+
+/**
+ * @brief Records an HTTP client request on the span event.
+ *
+ * Mirrors pinpoint::helper::TraceHttpClientRequest(span_event, host, url,
+ *                                                  request_reader).
+ */
+void pt_trace_http_client_request(pt_span_event_t se,
+                                  const char* host,
+                                  const char* url,
+                                  const pt_header_reader_t* request_reader);
+
+/**
+ * @brief Records an HTTP client request with cookies on the span event.
+ *
+ * Mirrors pinpoint::helper::TraceHttpClientRequest(span_event, host, url,
+ *                                                  request_reader, cookie_reader).
+ */
+void pt_trace_http_client_request_with_cookie(pt_span_event_t se,
+                                              const char* host,
+                                              const char* url,
+                                              const pt_header_reader_t* request_reader,
+                                              const pt_header_reader_t* cookie_reader);
+
+/**
+ * @brief Records an HTTP client response on the span event.
+ *
+ * Mirrors pinpoint::helper::TraceHttpClientResponse().
+ */
+void pt_trace_http_client_response(pt_span_event_t se,
+                                   int status_code,
+                                   const pt_header_reader_t* response_reader);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PINPOINT_TRACER_C_H */

--- a/src/tracer_c.cpp
+++ b/src/tracer_c.cpp
@@ -1,0 +1,632 @@
+/*
+ * Copyright 2020-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file tracer_c.cpp
+ * @brief C++ implementation of the pure-C public API declared in tracer_c.h.
+ *
+ * Each C handle type wraps a C++ shared_ptr so that object lifetimes are
+ * managed safely even when the C caller mixes pt_span_destroy() with
+ * pt_span_new_async_span() or pt_span_get_event().
+ *
+ * Adapter classes (CContextReader, CHeaderReader, CContextWriter,
+ * CCallstackReader) bridge the C callback structs to the corresponding
+ * pure-virtual C++ interfaces without heap allocation — they are
+ * constructed on the stack at each call site.
+ */
+
+#include "pinpoint/tracer_c.h"
+#include "pinpoint/tracer.h"
+
+#include <chrono>
+#include <cstring>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+// ============================================================================
+// Opaque handle definitions
+// ============================================================================
+
+struct pt_agent_s      { pinpoint::AgentPtr      ptr; };
+struct pt_span_s       { pinpoint::SpanPtr        ptr; };
+struct pt_span_event_s { pinpoint::SpanEventPtr   ptr; };
+struct pt_annotation_s { pinpoint::AnnotationPtr  ptr; };
+
+// ============================================================================
+// Trampoline helpers
+//
+// C++ std::function closures cannot be converted to plain C function pointers.
+// We use a small context struct placed on the caller's stack together with a
+// file-scope trampoline function to bridge between the two worlds without any
+// heap allocation.
+// ============================================================================
+
+struct ForEachCtx {
+    const std::function<bool(std::string_view, std::string_view)>* cb;
+};
+
+static int for_each_trampoline(const char* key, const char* value, void* userdata) {
+    const auto* ctx = static_cast<const ForEachCtx*>(userdata);
+    // Return 0 to continue, non-zero to stop — mirrors the C callback contract.
+    return (*ctx->cb)(key, value) ? 0 : 1;
+}
+
+struct CallstackForEachCtx {
+    const std::function<void(std::string_view, std::string_view, std::string_view, int)>* cb;
+};
+
+static void callstack_foreach_trampoline(const char* mod, const char* fn,
+                                         const char* file, int line,
+                                         void* userdata) {
+    const auto* ctx = static_cast<const CallstackForEachCtx*>(userdata);
+    (*ctx->cb)(mod ? mod : "", fn ? fn : "", file ? file : "", line);
+}
+
+// ============================================================================
+// C++ adapter classes — stack-allocated, zero-heap-overhead bridges
+// ============================================================================
+
+/**
+ * Wraps pt_context_reader_t as a pinpoint::TraceContextReader.
+ */
+class CContextReader final : public pinpoint::TraceContextReader {
+public:
+    explicit CContextReader(const pt_context_reader_t* r) : r_(r) {}
+
+    std::optional<std::string> Get(std::string_view key) const override {
+        if (!r_ || !r_->get) return std::nullopt;
+        std::string k(key);
+        const char* v = r_->get(r_->userdata, k.c_str());
+        return v ? std::optional<std::string>(v) : std::nullopt;
+    }
+
+private:
+    const pt_context_reader_t* r_;
+};
+
+/**
+ * Wraps pt_header_reader_t as a pinpoint::HeaderReader.
+ */
+class CHeaderReader final : public pinpoint::HeaderReader {
+public:
+    explicit CHeaderReader(const pt_header_reader_t* r) : r_(r) {}
+
+    std::optional<std::string> Get(std::string_view key) const override {
+        if (!r_ || !r_->get) return std::nullopt;
+        std::string k(key);
+        const char* v = r_->get(r_->userdata, k.c_str());
+        return v ? std::optional<std::string>(v) : std::nullopt;
+    }
+
+    void ForEach(std::function<bool(std::string_view, std::string_view)> cb) const override {
+        if (!r_ || !r_->for_each) return;
+        ForEachCtx ctx{&cb};
+        r_->for_each(r_->userdata, for_each_trampoline, &ctx);
+    }
+
+private:
+    const pt_header_reader_t* r_;
+};
+
+/**
+ * Wraps pt_context_writer_t as a pinpoint::TraceContextWriter.
+ */
+class CContextWriter final : public pinpoint::TraceContextWriter {
+public:
+    explicit CContextWriter(pt_context_writer_t* w) : w_(w) {}
+
+    void Set(std::string_view key, std::string_view value) override {
+        if (!w_ || !w_->set) return;
+        std::string k(key), v(value);
+        w_->set(w_->userdata, k.c_str(), v.c_str());
+    }
+
+private:
+    pt_context_writer_t* w_;
+};
+
+/**
+ * Wraps pt_callstack_reader_t as a pinpoint::CallStackReader.
+ */
+class CCallstackReader final : public pinpoint::CallStackReader {
+public:
+    explicit CCallstackReader(const pt_callstack_reader_t* r) : r_(r) {}
+
+    void ForEach(std::function<void(std::string_view, std::string_view,
+                                    std::string_view, int)> cb) const override {
+        if (!r_ || !r_->for_each) return;
+        CallstackForEachCtx ctx{&cb};
+        r_->for_each(r_->userdata, callstack_foreach_trampoline, &ctx);
+    }
+
+private:
+    const pt_callstack_reader_t* r_;
+};
+
+// ============================================================================
+// Utility helpers
+// ============================================================================
+
+static inline std::chrono::system_clock::time_point ms_to_time_point(int64_t ms) {
+    return std::chrono::system_clock::time_point(std::chrono::milliseconds(ms));
+}
+
+static inline void fill_trace_id(pt_trace_id_t* out, pinpoint::TraceId& tid) {
+    std::strncpy(out->agent_id, tid.AgentId.c_str(), PT_AGENT_ID_MAX - 1);
+    out->agent_id[PT_AGENT_ID_MAX - 1] = '\0';
+    out->start_time = tid.StartTime;
+    out->sequence   = tid.Sequence;
+}
+
+// ============================================================================
+// Global configuration
+// ============================================================================
+
+void pt_set_config_file_path(const char* config_file_path) {
+    if (config_file_path) {
+        pinpoint::SetConfigFilePath(config_file_path);
+    }
+}
+
+void pt_set_config_string(const char* config_string) {
+    if (config_string) {
+        pinpoint::SetConfigString(config_string);
+    }
+}
+
+// ============================================================================
+// Agent lifecycle
+// ============================================================================
+
+pt_agent_t pt_create_agent(void) {
+    auto ptr = pinpoint::CreateAgent();
+    if (!ptr) return nullptr;
+    return new pt_agent_s{std::move(ptr)};
+}
+
+pt_agent_t pt_create_agent_with_type(int32_t app_type) {
+    auto ptr = pinpoint::CreateAgent(app_type);
+    if (!ptr) return nullptr;
+    return new pt_agent_s{std::move(ptr)};
+}
+
+pt_agent_t pt_global_agent(void) {
+    auto ptr = pinpoint::GlobalAgent();
+    if (!ptr) return nullptr;
+    // Wrap in a non-owning sentinel: we allocate a handle but the shared_ptr
+    // keeps the global agent alive regardless of whether the caller ever calls
+    // pt_agent_destroy() on this handle.
+    return new pt_agent_s{std::move(ptr)};
+}
+
+void pt_agent_destroy(pt_agent_t agent) {
+    delete agent;
+}
+
+int pt_agent_is_enabled(pt_agent_t agent) {
+    if (!agent || !agent->ptr) return 0;
+    return agent->ptr->Enable() ? 1 : 0;
+}
+
+void pt_agent_shutdown(pt_agent_t agent) {
+    if (agent && agent->ptr) {
+        agent->ptr->Shutdown();
+    }
+}
+
+// ============================================================================
+// Span creation
+// ============================================================================
+
+pt_span_t pt_agent_new_span(pt_agent_t agent, const char* operation,
+                            const char* rpc_point) {
+    if (!agent || !agent->ptr) return nullptr;
+    auto ptr = agent->ptr->NewSpan(operation ? operation : "",
+                                   rpc_point  ? rpc_point  : "");
+    if (!ptr) return nullptr;
+    return new pt_span_s{std::move(ptr)};
+}
+
+pt_span_t pt_agent_new_span_with_reader(pt_agent_t agent, const char* operation,
+                                        const char* rpc_point,
+                                        const pt_context_reader_t* reader) {
+    if (!agent || !agent->ptr) return nullptr;
+    pinpoint::SpanPtr ptr;
+    if (reader) {
+        CContextReader cpt_reader(reader);
+        ptr = agent->ptr->NewSpan(operation ? operation : "",
+                                  rpc_point  ? rpc_point  : "",
+                                  cpt_reader);
+    } else {
+        ptr = agent->ptr->NewSpan(operation ? operation : "",
+                                  rpc_point  ? rpc_point  : "");
+    }
+    if (!ptr) return nullptr;
+    return new pt_span_s{std::move(ptr)};
+}
+
+pt_span_t pt_agent_new_span_with_method(pt_agent_t agent, const char* operation,
+                                        const char* rpc_point, const char* method,
+                                        const pt_context_reader_t* reader) {
+    if (!agent || !agent->ptr) return nullptr;
+    pinpoint::SpanPtr ptr;
+    if (reader) {
+        CContextReader cpt_reader(reader);
+        ptr = agent->ptr->NewSpan(operation ? operation : "",
+                                  rpc_point  ? rpc_point  : "",
+                                  method     ? method     : "",
+                                  cpt_reader);
+    } else {
+        ptr = agent->ptr->NewSpan(operation ? operation : "",
+                                  rpc_point  ? rpc_point  : "");
+    }
+    if (!ptr) return nullptr;
+    return new pt_span_s{std::move(ptr)};
+}
+
+// ============================================================================
+// Span operations
+// ============================================================================
+
+void pt_span_destroy(pt_span_t span) {
+    delete span;
+}
+
+pt_span_event_t pt_span_new_event(pt_span_t span, const char* operation) {
+    if (!span || !span->ptr) return nullptr;
+    auto ptr = span->ptr->NewSpanEvent(operation ? operation : "");
+    if (!ptr) return nullptr;
+    return new pt_span_event_s{std::move(ptr)};
+}
+
+pt_span_event_t pt_span_new_event_with_type(pt_span_t span, const char* operation,
+                                            int32_t service_type) {
+    if (!span || !span->ptr) return nullptr;
+    auto ptr = span->ptr->NewSpanEvent(operation ? operation : "", service_type);
+    if (!ptr) return nullptr;
+    return new pt_span_event_s{std::move(ptr)};
+}
+
+pt_span_event_t pt_span_get_event(pt_span_t span) {
+    if (!span || !span->ptr) return nullptr;
+    auto ptr = span->ptr->GetSpanEvent();
+    if (!ptr) return nullptr;
+    return new pt_span_event_s{std::move(ptr)};
+}
+
+void pt_span_end_event(pt_span_t span) {
+    if (span && span->ptr) {
+        span->ptr->EndSpanEvent();
+    }
+}
+
+void pt_span_end(pt_span_t span) {
+    if (span && span->ptr) {
+        span->ptr->EndSpan();
+    }
+}
+
+pt_span_t pt_span_new_async_span(pt_span_t span, const char* async_operation) {
+    if (!span || !span->ptr) return nullptr;
+    auto ptr = span->ptr->NewAsyncSpan(async_operation ? async_operation : "");
+    if (!ptr) return nullptr;
+    return new pt_span_s{std::move(ptr)};
+}
+
+void pt_span_inject_context(pt_span_t span, pt_context_writer_t* writer) {
+    if (!span || !span->ptr || !writer) return;
+    CContextWriter cpt_writer(writer);
+    span->ptr->InjectContext(cpt_writer);
+}
+
+void pt_span_extract_context(pt_span_t span, const pt_context_reader_t* reader) {
+    if (!span || !span->ptr || !reader) return;
+    CContextReader cpt_reader(reader);
+    span->ptr->ExtractContext(cpt_reader);
+}
+
+pt_trace_id_t pt_span_get_trace_id(pt_span_t span) {
+    pt_trace_id_t result{};
+    if (span && span->ptr) {
+        fill_trace_id(&result, span->ptr->GetTraceId());
+    }
+    return result;
+}
+
+int64_t pt_span_get_span_id(pt_span_t span) {
+    if (!span || !span->ptr) return 0;
+    return span->ptr->GetSpanId();
+}
+
+int pt_span_is_sampled(pt_span_t span) {
+    if (!span || !span->ptr) return 0;
+    return span->ptr->IsSampled() ? 1 : 0;
+}
+
+void pt_span_set_service_type(pt_span_t span, int32_t service_type) {
+    if (span && span->ptr) span->ptr->SetServiceType(service_type);
+}
+
+void pt_span_set_start_time_ms(pt_span_t span, int64_t ms_since_epoch) {
+    if (span && span->ptr) {
+        span->ptr->SetStartTime(ms_to_time_point(ms_since_epoch));
+    }
+}
+
+void pt_span_set_remote_address(pt_span_t span, const char* address) {
+    if (span && span->ptr && address) span->ptr->SetRemoteAddress(address);
+}
+
+void pt_span_set_end_point(pt_span_t span, const char* end_point) {
+    if (span && span->ptr && end_point) span->ptr->SetEndPoint(end_point);
+}
+
+void pt_span_set_error(pt_span_t span, const char* error_message) {
+    if (span && span->ptr && error_message) span->ptr->SetError(error_message);
+}
+
+void pt_span_set_error_named(pt_span_t span, const char* error_name,
+                             const char* error_message) {
+    if (span && span->ptr && error_name && error_message) {
+        span->ptr->SetError(error_name, error_message);
+    }
+}
+
+void pt_span_set_status_code(pt_span_t span, int status_code) {
+    if (span && span->ptr) span->ptr->SetStatusCode(status_code);
+}
+
+void pt_span_set_url_stat(pt_span_t span, const char* url_pattern,
+                          const char* method, int status_code) {
+    if (span && span->ptr) {
+        span->ptr->SetUrlStat(url_pattern ? url_pattern : "",
+                              method      ? method      : "",
+                              status_code);
+    }
+}
+
+void pt_span_set_logging(pt_span_t span, pt_context_writer_t* writer) {
+    if (!span || !span->ptr || !writer) return;
+    CContextWriter cpt_writer(writer);
+    span->ptr->SetLogging(cpt_writer);
+}
+
+void pt_span_record_header(pt_span_t span, pt_header_type_t which,
+                           const pt_header_reader_t* reader) {
+    if (!span || !span->ptr || !reader) return;
+    CHeaderReader cpt_reader(reader);
+    span->ptr->RecordHeader(static_cast<pinpoint::HeaderType>(which), cpt_reader);
+}
+
+pt_annotation_t pt_span_get_annotations(pt_span_t span) {
+    if (!span || !span->ptr) return nullptr;
+    auto ptr = span->ptr->GetAnnotations();
+    if (!ptr) return nullptr;
+    return new pt_annotation_s{std::move(ptr)};
+}
+
+// ============================================================================
+// SpanEvent operations
+// ============================================================================
+
+void pt_span_event_destroy(pt_span_event_t se) {
+    delete se;
+}
+
+void pt_span_event_set_service_type(pt_span_event_t se, int32_t service_type) {
+    if (se && se->ptr) se->ptr->SetServiceType(service_type);
+}
+
+void pt_span_event_set_operation_name(pt_span_event_t se, const char* operation) {
+    if (se && se->ptr && operation) se->ptr->SetOperationName(operation);
+}
+
+void pt_span_event_set_start_time_ms(pt_span_event_t se, int64_t ms_since_epoch) {
+    if (se && se->ptr) {
+        se->ptr->SetStartTime(ms_to_time_point(ms_since_epoch));
+    }
+}
+
+void pt_span_event_set_destination(pt_span_event_t se, const char* dest) {
+    if (se && se->ptr && dest) se->ptr->SetDestination(dest);
+}
+
+void pt_span_event_set_end_point(pt_span_event_t se, const char* end_point) {
+    if (se && se->ptr && end_point) se->ptr->SetEndPoint(end_point);
+}
+
+void pt_span_event_set_error(pt_span_event_t se, const char* error_message) {
+    if (se && se->ptr && error_message) se->ptr->SetError(error_message);
+}
+
+void pt_span_event_set_error_named(pt_span_event_t se, const char* error_name,
+                                   const char* error_message) {
+    if (se && se->ptr && error_name && error_message) {
+        se->ptr->SetError(error_name, error_message);
+    }
+}
+
+void pt_span_event_set_error_with_callstack(pt_span_event_t se,
+                                            const char* error_name,
+                                            const char* error_message,
+                                            const pt_callstack_reader_t* reader) {
+    if (!se || !se->ptr) return;
+    const char* name = error_name    ? error_name    : "";
+    const char* msg  = error_message ? error_message : "";
+    if (reader) {
+        CCallstackReader cpt_reader(reader);
+        se->ptr->SetError(name, msg, cpt_reader);
+    } else {
+        se->ptr->SetError(name, msg);
+    }
+}
+
+void pt_span_event_set_sql_query(pt_span_event_t se, const char* sql_query,
+                                 const char* args) {
+    if (se && se->ptr) {
+        se->ptr->SetSqlQuery(sql_query ? sql_query : "",
+                             args      ? args      : "");
+    }
+}
+
+void pt_span_event_record_header(pt_span_event_t se, pt_header_type_t which,
+                                 const pt_header_reader_t* reader) {
+    if (!se || !se->ptr || !reader) return;
+    CHeaderReader cpt_reader(reader);
+    se->ptr->RecordHeader(static_cast<pinpoint::HeaderType>(which), cpt_reader);
+}
+
+pt_annotation_t pt_span_event_get_annotations(pt_span_event_t se) {
+    if (!se || !se->ptr) return nullptr;
+    auto ptr = se->ptr->GetAnnotations();
+    if (!ptr) return nullptr;
+    return new pt_annotation_s{std::move(ptr)};
+}
+
+// ============================================================================
+// Annotation operations
+// ============================================================================
+
+void pt_annotation_destroy(pt_annotation_t anno) {
+    delete anno;
+}
+
+void pt_annotation_append_int(pt_annotation_t anno, int32_t key, int32_t value) {
+    if (anno && anno->ptr) anno->ptr->AppendInt(key, value);
+}
+
+void pt_annotation_append_long(pt_annotation_t anno, int32_t key, int64_t value) {
+    if (anno && anno->ptr) anno->ptr->AppendLong(key, value);
+}
+
+void pt_annotation_append_string(pt_annotation_t anno, int32_t key, const char* value) {
+    if (anno && anno->ptr && value) anno->ptr->AppendString(key, value);
+}
+
+void pt_annotation_append_string_string(pt_annotation_t anno, int32_t key,
+                                        const char* s1, const char* s2) {
+    if (anno && anno->ptr) {
+        anno->ptr->AppendStringString(key, s1 ? s1 : "", s2 ? s2 : "");
+    }
+}
+
+void pt_annotation_append_int_string_string(pt_annotation_t anno, int32_t key,
+                                            int i, const char* s1, const char* s2) {
+    if (anno && anno->ptr) {
+        anno->ptr->AppendIntStringString(key, i, s1 ? s1 : "", s2 ? s2 : "");
+    }
+}
+
+void pt_annotation_append_bytes_string_string(pt_annotation_t anno, int32_t key,
+                                              const unsigned char* uid, int uid_len,
+                                              const char* s1, const char* s2) {
+    if (!anno || !anno->ptr || !uid || uid_len <= 0) return;
+    std::vector<unsigned char> v(uid, uid + uid_len);
+    anno->ptr->AppendBytesStringString(key, std::move(v),
+                                       s1 ? s1 : "", s2 ? s2 : "");
+}
+
+void pt_annotation_append_long_int_int_byte_byte_string(pt_annotation_t anno,
+                                                        int32_t key,
+                                                        int64_t l,
+                                                        int32_t i1, int32_t i2,
+                                                        int32_t b1, int32_t b2,
+                                                        const char* s) {
+    if (anno && anno->ptr) {
+        anno->ptr->AppendLongIntIntByteByteString(key, l, i1, i2, b1, b2,
+                                                  s ? s : "");
+    }
+}
+
+// ============================================================================
+// HTTP helper functions
+// ============================================================================
+
+void pt_trace_http_server_request(pt_span_t span,
+                                  const char* remote_addr,
+                                  const char* endpoint,
+                                  const pt_header_reader_t* request_reader) {
+    if (!span || !span->ptr || !request_reader) return;
+    CHeaderReader cpt_req(request_reader);
+    pinpoint::helper::TraceHttpServerRequest(span->ptr,
+                                             remote_addr ? remote_addr : "",
+                                             endpoint    ? endpoint    : "",
+                                             cpt_req);
+}
+
+void pt_trace_http_server_request_with_cookie(pt_span_t span,
+                                              const char* remote_addr,
+                                              const char* endpoint,
+                                              const pt_header_reader_t* request_reader,
+                                              const pt_header_reader_t* cookie_reader) {
+    if (!span || !span->ptr || !request_reader || !cookie_reader) return;
+    CHeaderReader cpt_req(request_reader);
+    CHeaderReader cpt_cookie(cookie_reader);
+    pinpoint::helper::TraceHttpServerRequest(span->ptr,
+                                             remote_addr ? remote_addr : "",
+                                             endpoint    ? endpoint    : "",
+                                             cpt_req, cpt_cookie);
+}
+
+void pt_trace_http_server_response(pt_span_t span,
+                                   const char* url_pattern,
+                                   const char* method,
+                                   int status_code,
+                                   const pt_header_reader_t* response_reader) {
+    if (!span || !span->ptr || !response_reader) return;
+    CHeaderReader cpt_resp(response_reader);
+    pinpoint::helper::TraceHttpServerResponse(span->ptr,
+                                              url_pattern ? url_pattern : "",
+                                              method      ? method      : "",
+                                              status_code,
+                                              cpt_resp);
+}
+
+void pt_trace_http_client_request(pt_span_event_t se,
+                                  const char* host,
+                                  const char* url,
+                                  const pt_header_reader_t* request_reader) {
+    if (!se || !se->ptr || !request_reader) return;
+    CHeaderReader cpt_req(request_reader);
+    pinpoint::helper::TraceHttpClientRequest(se->ptr,
+                                             host ? host : "",
+                                             url  ? url  : "",
+                                             cpt_req);
+}
+
+void pt_trace_http_client_request_with_cookie(pt_span_event_t se,
+                                              const char* host,
+                                              const char* url,
+                                              const pt_header_reader_t* request_reader,
+                                              const pt_header_reader_t* cookie_reader) {
+    if (!se || !se->ptr || !request_reader || !cookie_reader) return;
+    CHeaderReader cpt_req(request_reader);
+    CHeaderReader cpt_cookie(cookie_reader);
+    pinpoint::helper::TraceHttpClientRequest(se->ptr,
+                                             host ? host : "",
+                                             url  ? url  : "",
+                                             cpt_req, cpt_cookie);
+}
+
+void pt_trace_http_client_response(pt_span_event_t se,
+                                   int status_code,
+                                   const pt_header_reader_t* response_reader) {
+    if (!se || !se->ptr || !response_reader) return;
+    CHeaderReader cpt_resp(response_reader);
+    pinpoint::helper::TraceHttpClientResponse(se->ptr, status_code, cpt_resp);
+}

--- a/test/BUILD
+++ b/test/BUILD
@@ -159,6 +159,14 @@ cc_test(
     deps = [":test_gmock"],
 )
 
+# C API tests
+cc_test(
+    name = "test_tracer_c",
+    size = "small",
+    srcs = ["test_tracer_c.cpp"],
+    deps = [":test_gmock"],
+)
+
 # Test suite for all tests
 test_suite(
     name = "all_tests",
@@ -177,6 +185,7 @@ test_suite(
         ":test_span_event",
         ":test_sql",
         ":test_stat",
+        ":test_tracer_c",
         ":test_url_stat",
     ],
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -209,5 +209,14 @@ target_link_libraries(test_logging
 set_target_properties(test_logging PROPERTIES CXX_STANDARD 17)
 add_test(NAME test_logging COMMAND test_logging)
 
+# C API tests
+add_executable(test_tracer_c test_tracer_c.cpp)
+target_link_libraries(test_tracer_c
+    ${PINPOINT_CPP_LIBRARY}
+    GTest::gmock_main
+)
+set_target_properties(test_tracer_c PROPERTIES CXX_STANDARD 17)
+add_test(NAME test_tracer_c COMMAND test_tracer_c)
+
 # Integration test
 add_subdirectory(it_test)

--- a/test/test_tracer_c.cpp
+++ b/test/test_tracer_c.cpp
@@ -1,0 +1,956 @@
+/*
+ * Copyright 2020-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_tracer_c.cpp
+ * @brief Unit tests for the pure-C public API (include/pinpoint/tracer_c.h).
+ *
+ * This file is compiled as C++ so that GoogleTest and the mock gRPC
+ * infrastructure can be used, but it exercises only functions and types
+ * declared in tracer_c.h — the same header that C applications include.
+ *
+ * A mock-backed pinpoint::AgentImpl is installed as the global agent via
+ * the internal set_global_agent() helper so that tests run without a real
+ * Pinpoint collector.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <atomic>
+#include <chrono>
+#include <map>
+#include <string>
+#include <thread>
+#include <vector>
+
+// C API under test — included exactly as a C application would include it.
+#include "pinpoint/tracer_c.h"
+
+// Internal headers needed only to set up the mock agent for testing.
+#include "../src/agent.h"
+#include "../src/config.h"
+#include "../src/grpc.h"
+#include "../src/noop.h"
+#include "v1/Service_mock.grpc.pb.h"
+
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+// ============================================================================
+// Mock gRPC infrastructure (same pattern as test_agent_with_mocks.cpp)
+// ============================================================================
+
+namespace {
+
+class TestableGrpcAgent : public pinpoint::GrpcAgent {
+public:
+    explicit TestableGrpcAgent(std::shared_ptr<const pinpoint::Config> cfg)
+        : GrpcAgent(std::move(cfg)) {}
+
+    void injectMockStubs() {
+        auto agent_stub = std::make_unique<NiceMock<v1::MockAgentStub>>();
+        EXPECT_CALL(*agent_stub, RequestAgentInfo(_, _, _))
+            .WillRepeatedly(Return(grpc::Status::OK));
+        set_agent_stub(std::move(agent_stub));
+
+        auto meta_stub = std::make_unique<NiceMock<v1::MockMetadataStub>>();
+        EXPECT_CALL(*meta_stub, RequestApiMetaData(_, _, _))
+            .WillRepeatedly(Return(grpc::Status::OK));
+        EXPECT_CALL(*meta_stub, RequestStringMetaData(_, _, _))
+            .WillRepeatedly(Return(grpc::Status::OK));
+        EXPECT_CALL(*meta_stub, RequestSqlMetaData(_, _, _))
+            .WillRepeatedly(Return(grpc::Status::OK));
+        EXPECT_CALL(*meta_stub, RequestSqlUidMetaData(_, _, _))
+            .WillRepeatedly(Return(grpc::Status::OK));
+        set_meta_stub(std::move(meta_stub));
+    }
+
+    bool readyChannel() override { return ready_count_++ == 0; }
+    pinpoint::GrpcRequestStatus registerAgent() override { return pinpoint::SEND_OK; }
+
+private:
+    std::atomic<int> ready_count_{0};
+};
+
+class TestableGrpcSpan : public pinpoint::GrpcSpan {
+public:
+    explicit TestableGrpcSpan(std::shared_ptr<const pinpoint::Config> cfg)
+        : GrpcSpan(std::move(cfg)) {}
+
+    void injectMockStubs() {
+        set_span_stub(std::make_unique<NiceMock<v1::MockSpanStub>>());
+    }
+
+    bool readyChannel() override { return false; }
+};
+
+class TestableGrpcStats : public pinpoint::GrpcStats {
+public:
+    explicit TestableGrpcStats(std::shared_ptr<const pinpoint::Config> cfg)
+        : GrpcStats(std::move(cfg)) {}
+
+    void injectMockStubs() {
+        set_stats_stub(std::make_unique<NiceMock<v1::MockStatStub>>());
+    }
+
+    bool readyChannel() override { return false; }
+};
+
+static std::shared_ptr<pinpoint::Config> make_test_config() {
+    auto cfg = std::make_shared<pinpoint::Config>();
+    cfg->enable              = true;
+    cfg->app_name_           = "c-api-test";
+    cfg->app_type_           = PT_APP_TYPE_CPP;
+    cfg->agent_id_           = "c-api-agent";
+    cfg->agent_name_         = "c-api-agent-name";
+    cfg->collector.host      = "127.0.0.1";
+    cfg->collector.agent_port = 9991;
+    cfg->collector.span_port  = 9993;
+    cfg->collector.stat_port  = 9992;
+    cfg->span.queue_size      = 1024;
+    cfg->span.event_chunk_size = 10;
+    cfg->span.max_event_depth  = 32;
+    cfg->stat.enable           = true;
+    cfg->stat.collect_interval = 5000;
+    cfg->http.url_stat.enable  = false;
+    cfg->sampling.type         = "counter";
+    cfg->sampling.counter_rate = 1;
+    return cfg;
+}
+
+static std::shared_ptr<pinpoint::AgentImpl> make_test_agent(
+        std::shared_ptr<pinpoint::Config> cfg) {
+    auto grpc_agent = std::make_unique<TestableGrpcAgent>(cfg);
+    auto grpc_span  = std::make_unique<TestableGrpcSpan>(cfg);
+    auto grpc_stat  = std::make_unique<TestableGrpcStats>(cfg);
+
+    grpc_agent->injectMockStubs();
+    grpc_span->injectMockStubs();
+    grpc_stat->injectMockStubs();
+
+    return std::make_shared<pinpoint::AgentImpl>(
+        cfg,
+        std::move(grpc_agent),
+        std::move(grpc_span),
+        std::move(grpc_stat));
+}
+
+// ============================================================================
+// C-compatible callback helpers
+//
+// These are plain functions (no lambda captures) that implement the carrier
+// interfaces using std::map<std::string,std::string> as the backing store.
+// ============================================================================
+
+using HeaderMap = std::map<std::string, std::string>;
+
+static const char* hmap_get(void* ud, const char* key) {
+    auto* m = static_cast<HeaderMap*>(ud);
+    auto  it = m->find(key);
+    return it != m->end() ? it->second.c_str() : nullptr;
+}
+
+static void hmap_set(void* ud, const char* key, const char* value) {
+    (*static_cast<HeaderMap*>(ud))[key] = value;
+}
+
+static void hmap_foreach(void* ud, pt_header_foreach_cb cb, void* cb_ud) {
+    for (const auto& kv : *static_cast<HeaderMap*>(ud)) {
+        if (cb(kv.first.c_str(), kv.second.c_str(), cb_ud) != 0) break;
+    }
+}
+
+// Callstack data for testing.
+struct Frame { const char* mod; const char* fn; const char* file; int line; };
+static const Frame kTestFrames[] = {
+    { "libfoo", "foo::bar()",  "foo.cpp", 42 },
+    { "libfoo", "foo::entry()", "foo.cpp", 10 },
+};
+
+static void callstack_foreach(void* ud, pt_callstack_frame_cb cb, void* cb_ud) {
+    const auto* frames = static_cast<const Frame*>(ud);
+    for (int i = 0; i < 2; ++i) {
+        cb(frames[i].mod, frames[i].fn, frames[i].file, frames[i].line, cb_ud);
+    }
+}
+
+// ============================================================================
+// Base test fixture — installs a mock agent and exposes a pt_agent_t handle
+// ============================================================================
+
+class TracerCApiTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        pinpoint::reset_global_agent();
+        pinpoint::set_config_string("");
+
+        cfg_        = make_test_config();
+        mock_agent_ = make_test_agent(cfg_);
+        pinpoint::set_global_agent(mock_agent_);
+        wait_enabled();
+
+        // Obtain C handle from the global agent.
+        agent_ = pt_global_agent();
+        ASSERT_NE(agent_, nullptr);
+    }
+
+    void TearDown() override {
+        pt_agent_destroy(agent_);
+        agent_ = nullptr;
+
+        mock_agent_->Shutdown();
+        mock_agent_.reset();
+        pinpoint::reset_global_agent();
+        pinpoint::set_config_string("");
+    }
+
+    void wait_enabled(int timeout_ms = 3000) {
+        auto deadline = std::chrono::steady_clock::now()
+                      + std::chrono::milliseconds(timeout_ms);
+        while (!mock_agent_->Enable()
+               && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+    std::shared_ptr<pinpoint::Config>   cfg_;
+    std::shared_ptr<pinpoint::AgentImpl> mock_agent_;
+    pt_agent_t                           agent_ = nullptr;
+};
+
+}  // namespace
+
+// ============================================================================
+// 1. Constant values
+// ============================================================================
+
+TEST(TracerCConstantsTest, AnnotationKeys) {
+    EXPECT_EQ(PT_ANNOTATION_API,                  12);
+    EXPECT_EQ(PT_ANNOTATION_SQL_ID,               20);
+    EXPECT_EQ(PT_ANNOTATION_SQL_UID,              25);
+    EXPECT_EQ(PT_ANNOTATION_EXCEPTION_ID,         -52);
+    EXPECT_EQ(PT_ANNOTATION_HTTP_URL,             40);
+    EXPECT_EQ(PT_ANNOTATION_HTTP_STATUS_CODE,     46);
+    EXPECT_EQ(PT_ANNOTATION_HTTP_COOKIE,          45);
+    EXPECT_EQ(PT_ANNOTATION_HTTP_REQUEST_HEADER,  47);
+    EXPECT_EQ(PT_ANNOTATION_HTTP_RESPONSE_HEADER, 55);
+    EXPECT_EQ(PT_ANNOTATION_HTTP_PROXY_HEADER,    300);
+}
+
+TEST(TracerCConstantsTest, ServiceTypes) {
+    EXPECT_EQ(PT_APP_TYPE_CPP,                 1300);
+    EXPECT_EQ(PT_SERVICE_TYPE_CPP,             1300);
+    EXPECT_EQ(PT_SERVICE_TYPE_CPP_FUNC,        1301);
+    EXPECT_EQ(PT_SERVICE_TYPE_CPP_HTTP_CLIENT, 9800);
+    EXPECT_EQ(PT_SERVICE_TYPE_ASYNC,           100);
+    EXPECT_EQ(PT_SERVICE_TYPE_MYSQL_QUERY,     2101);
+    EXPECT_EQ(PT_SERVICE_TYPE_MSSQL_QUERY,     2201);
+    EXPECT_EQ(PT_SERVICE_TYPE_ORACLE_QUERY,    2301);
+    EXPECT_EQ(PT_SERVICE_TYPE_PGSQL_QUERY,     2501);
+    EXPECT_EQ(PT_SERVICE_TYPE_CASSANDRA_QUERY, 2601);
+    EXPECT_EQ(PT_SERVICE_TYPE_MONGODB_QUERY,   2651);
+    EXPECT_EQ(PT_SERVICE_TYPE_MEMCACHED,       8050);
+    EXPECT_EQ(PT_SERVICE_TYPE_REDIS,           8203);
+    EXPECT_EQ(PT_SERVICE_TYPE_KAFKA,           8660);
+    EXPECT_EQ(PT_SERVICE_TYPE_HBASE,           8800);
+    EXPECT_EQ(PT_SERVICE_TYPE_GRPC_CLIENT,     9160);
+    EXPECT_EQ(PT_SERVICE_TYPE_GRPC_SERVER,     1130);
+}
+
+TEST(TracerCConstantsTest, HeaderNames) {
+    EXPECT_STREQ(PT_HEADER_TRACE_ID,             "Pinpoint-TraceID");
+    EXPECT_STREQ(PT_HEADER_SPAN_ID,              "Pinpoint-SpanID");
+    EXPECT_STREQ(PT_HEADER_PARENT_SPAN_ID,       "Pinpoint-pSpanID");
+    EXPECT_STREQ(PT_HEADER_SAMPLED,              "Pinpoint-Sampled");
+    EXPECT_STREQ(PT_HEADER_FLAG,                 "Pinpoint-Flags");
+    EXPECT_STREQ(PT_HEADER_PARENT_APP_NAME,      "Pinpoint-pAppName");
+    EXPECT_STREQ(PT_HEADER_PARENT_APP_TYPE,      "Pinpoint-pAppType");
+    EXPECT_STREQ(PT_HEADER_PARENT_APP_NAMESPACE, "Pinpoint-pAppNamespace");
+    EXPECT_STREQ(PT_HEADER_HOST,                 "Pinpoint-Host");
+}
+
+// ============================================================================
+// 2. Agent lifecycle
+// ============================================================================
+
+TEST_F(TracerCApiTest, AgentIsEnabled) {
+    EXPECT_NE(pt_agent_is_enabled(agent_), 0);
+}
+
+TEST_F(TracerCApiTest, AgentShutdownDisablesAgent) {
+    EXPECT_NE(pt_agent_is_enabled(agent_), 0);
+    pt_agent_shutdown(agent_);
+    EXPECT_EQ(pt_agent_is_enabled(agent_), 0);
+}
+
+// ============================================================================
+// 3. Null-handle safety — no crashes on NULL inputs
+// ============================================================================
+
+TEST(TracerCNullSafetyTest, NullAgentCalls) {
+    EXPECT_NO_FATAL_FAILURE(pt_agent_is_enabled(nullptr));
+    EXPECT_NO_FATAL_FAILURE(pt_agent_shutdown(nullptr));
+    EXPECT_NO_FATAL_FAILURE(pt_agent_destroy(nullptr));
+    EXPECT_EQ(pt_agent_new_span(nullptr, "op", "/rpc"), nullptr);
+    EXPECT_EQ(pt_agent_new_span_with_reader(nullptr, "op", "/rpc", nullptr), nullptr);
+    EXPECT_EQ(pt_agent_new_span_with_method(nullptr, "op", "/rpc", "GET", nullptr), nullptr);
+}
+
+TEST(TracerCNullSafetyTest, NullSpanCalls) {
+    EXPECT_NO_FATAL_FAILURE(pt_span_destroy(nullptr));
+    EXPECT_EQ(pt_span_new_event(nullptr, "op"), nullptr);
+    EXPECT_EQ(pt_span_new_event_with_type(nullptr, "op", 0), nullptr);
+    EXPECT_EQ(pt_span_get_event(nullptr), nullptr);
+    EXPECT_NO_FATAL_FAILURE(pt_span_end_event(nullptr));
+    EXPECT_NO_FATAL_FAILURE(pt_span_end(nullptr));
+    EXPECT_EQ(pt_span_new_async_span(nullptr, "op"), nullptr);
+    EXPECT_NO_FATAL_FAILURE(pt_span_inject_context(nullptr, nullptr));
+    EXPECT_NO_FATAL_FAILURE(pt_span_extract_context(nullptr, nullptr));
+    EXPECT_EQ(pt_span_get_span_id(nullptr), 0);
+    EXPECT_EQ(pt_span_is_sampled(nullptr), 0);
+    EXPECT_NO_FATAL_FAILURE(pt_span_set_service_type(nullptr, 0));
+    EXPECT_NO_FATAL_FAILURE(pt_span_set_start_time_ms(nullptr, 0));
+    EXPECT_NO_FATAL_FAILURE(pt_span_set_remote_address(nullptr, "addr"));
+    EXPECT_NO_FATAL_FAILURE(pt_span_set_end_point(nullptr, "ep"));
+    EXPECT_NO_FATAL_FAILURE(pt_span_set_error(nullptr, "err"));
+    EXPECT_NO_FATAL_FAILURE(pt_span_set_error_named(nullptr, "n", "m"));
+    EXPECT_NO_FATAL_FAILURE(pt_span_set_status_code(nullptr, 200));
+    EXPECT_NO_FATAL_FAILURE(pt_span_set_url_stat(nullptr, "/", "GET", 200));
+    EXPECT_NO_FATAL_FAILURE(pt_span_set_logging(nullptr, nullptr));
+    EXPECT_NO_FATAL_FAILURE(pt_span_record_header(nullptr, PT_HTTP_REQUEST, nullptr));
+    EXPECT_EQ(pt_span_get_annotations(nullptr), nullptr);
+}
+
+TEST(TracerCNullSafetyTest, NullSpanEventCalls) {
+    EXPECT_NO_FATAL_FAILURE(pt_span_event_destroy(nullptr));
+    EXPECT_NO_FATAL_FAILURE(pt_span_event_set_service_type(nullptr, 0));
+    EXPECT_NO_FATAL_FAILURE(pt_span_event_set_operation_name(nullptr, "op"));
+    EXPECT_NO_FATAL_FAILURE(pt_span_event_set_start_time_ms(nullptr, 0));
+    EXPECT_NO_FATAL_FAILURE(pt_span_event_set_destination(nullptr, "dst"));
+    EXPECT_NO_FATAL_FAILURE(pt_span_event_set_end_point(nullptr, "ep"));
+    EXPECT_NO_FATAL_FAILURE(pt_span_event_set_error(nullptr, "err"));
+    EXPECT_NO_FATAL_FAILURE(pt_span_event_set_error_named(nullptr, "n", "m"));
+    EXPECT_NO_FATAL_FAILURE(pt_span_event_set_error_with_callstack(nullptr, "n", "m", nullptr));
+    EXPECT_NO_FATAL_FAILURE(pt_span_event_set_sql_query(nullptr, "SELECT 1", ""));
+    EXPECT_NO_FATAL_FAILURE(pt_span_event_record_header(nullptr, PT_HTTP_REQUEST, nullptr));
+    EXPECT_EQ(pt_span_event_get_annotations(nullptr), nullptr);
+}
+
+TEST(TracerCNullSafetyTest, NullAnnotationCalls) {
+    EXPECT_NO_FATAL_FAILURE(pt_annotation_destroy(nullptr));
+    EXPECT_NO_FATAL_FAILURE(pt_annotation_append_int(nullptr, PT_ANNOTATION_API, 0));
+    EXPECT_NO_FATAL_FAILURE(pt_annotation_append_long(nullptr, PT_ANNOTATION_API, 0));
+    EXPECT_NO_FATAL_FAILURE(pt_annotation_append_string(nullptr, PT_ANNOTATION_API, "s"));
+    EXPECT_NO_FATAL_FAILURE(pt_annotation_append_string_string(nullptr, PT_ANNOTATION_API, "a", "b"));
+    EXPECT_NO_FATAL_FAILURE(pt_annotation_append_int_string_string(nullptr, PT_ANNOTATION_API, 1, "a", "b"));
+    EXPECT_NO_FATAL_FAILURE(pt_annotation_append_bytes_string_string(nullptr, PT_ANNOTATION_API, nullptr, 0, "a", "b"));
+    EXPECT_NO_FATAL_FAILURE(pt_annotation_append_long_int_int_byte_byte_string(nullptr, PT_ANNOTATION_API, 0, 0, 0, 0, 0, "s"));
+}
+
+// ============================================================================
+// 4. Span creation
+// ============================================================================
+
+TEST_F(TracerCApiTest, NewSpanReturnsHandle) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, NewSpanWithReaderExtracts) {
+    // Pre-populate a carrier that has no Pinpoint headers — should still
+    // succeed and return a valid (root) span.
+    HeaderMap headers;
+    pt_context_reader_t reader{&headers, hmap_get};
+
+    pt_span_t span = pt_agent_new_span_with_reader(agent_, "op", "/rpc", &reader);
+    ASSERT_NE(span, nullptr);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, NewSpanWithReaderNullFallsBack) {
+    pt_span_t span = pt_agent_new_span_with_reader(agent_, "op", "/rpc", nullptr);
+    ASSERT_NE(span, nullptr);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, NewSpanWithMethod) {
+    HeaderMap headers;
+    pt_context_reader_t reader{&headers, hmap_get};
+
+    pt_span_t span = pt_agent_new_span_with_method(agent_, "op", "/rpc", "POST", &reader);
+    ASSERT_NE(span, nullptr);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+// ============================================================================
+// 5. Span metadata setters
+// ============================================================================
+
+TEST_F(TracerCApiTest, SpanSettersDontCrash) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_set_service_type(span, PT_SERVICE_TYPE_CPP);
+    pt_span_set_start_time_ms(span, 1700000000000LL);
+    pt_span_set_remote_address(span, "10.0.0.1");
+    pt_span_set_end_point(span, "myhost:8080");
+    pt_span_set_error(span, "something went wrong");
+    pt_span_set_error_named(span, "RuntimeError", "index out of bounds");
+    pt_span_set_status_code(span, 500);
+    pt_span_set_url_stat(span, "/api/v1/users", "GET", 200);
+
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+// ============================================================================
+// 6. Span identifier accessors
+// ============================================================================
+
+TEST_F(TracerCApiTest, GetSpanIdReturnsNonZero) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    EXPECT_NE(pt_span_get_span_id(span), 0);
+    EXPECT_NE(pt_span_is_sampled(span), 0);
+
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, GetTraceIdFillsStruct) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_trace_id_t tid = pt_span_get_trace_id(span);
+    EXPECT_STRNE(tid.agent_id, "");
+    EXPECT_NE(tid.start_time, 0);
+
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+// ============================================================================
+// 7. Context injection / extraction
+// ============================================================================
+
+TEST_F(TracerCApiTest, InjectContextWritesHeaders) {
+    // InjectContext uses the active span event to generate the child span ID,
+    // so a span event must be open before calling inject.
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_event_t se = pt_span_new_event_with_type(span, "http_out",
+                                                      PT_SERVICE_TYPE_CPP_HTTP_CLIENT);
+    ASSERT_NE(se, nullptr);
+
+    HeaderMap out;
+    pt_context_writer_t writer{&out, hmap_set};
+    pt_span_inject_context(span, &writer);
+
+    // After injection the trace-id header must be present.
+    EXPECT_FALSE(out.empty());
+    EXPECT_NE(out.find(PT_HEADER_TRACE_ID), out.end());
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(se);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, ExtractContextFromInjectedHeaders) {
+    // Create a parent span with an active span event and inject its context.
+    pt_span_t parent = pt_agent_new_span(agent_, "parent", "/rpc");
+    ASSERT_NE(parent, nullptr);
+
+    pt_span_event_t parent_se = pt_span_new_event_with_type(parent, "http_out",
+                                                             PT_SERVICE_TYPE_CPP_HTTP_CLIENT);
+    ASSERT_NE(parent_se, nullptr);
+
+    HeaderMap carrier;
+    pt_context_writer_t writer{&carrier, hmap_set};
+    pt_span_inject_context(parent, &writer);
+    ASSERT_FALSE(carrier.empty());
+
+    // Create a child span by extracting from the carrier.
+    pt_context_reader_t reader{&carrier, hmap_get};
+    pt_span_t child = pt_agent_new_span_with_reader(agent_, "child", "/rpc", &reader);
+    ASSERT_NE(child, nullptr);
+
+    // Child must share the same trace-id as the parent.
+    pt_trace_id_t parent_tid = pt_span_get_trace_id(parent);
+    pt_trace_id_t child_tid  = pt_span_get_trace_id(child);
+    EXPECT_STREQ(parent_tid.agent_id, child_tid.agent_id);
+    EXPECT_EQ(parent_tid.start_time, child_tid.start_time);
+    EXPECT_EQ(parent_tid.sequence, child_tid.sequence);
+
+    pt_span_end(child);
+    pt_span_destroy(child);
+    pt_span_end_event(parent);
+    pt_span_event_destroy(parent_se);
+    pt_span_end(parent);
+    pt_span_destroy(parent);
+}
+
+// ============================================================================
+// 8. Span event lifecycle
+// ============================================================================
+
+TEST_F(TracerCApiTest, SpanEventLifecycle) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_event_t se = pt_span_new_event(span, "db_query");
+    ASSERT_NE(se, nullptr);
+
+    pt_span_event_set_service_type(se, PT_SERVICE_TYPE_MYSQL_QUERY);
+    pt_span_event_set_operation_name(se, "SELECT users");
+    pt_span_event_set_destination(se, "mydb");
+    pt_span_event_set_end_point(se, "db-host:3306");
+    pt_span_event_set_sql_query(se, "SELECT * FROM users WHERE id = ?", "42");
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(se);
+
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, SpanEventWithType) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_event_t se = pt_span_new_event_with_type(span, "http_call",
+                                                      PT_SERVICE_TYPE_CPP_HTTP_CLIENT);
+    ASSERT_NE(se, nullptr);
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(se);
+
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, SpanEventSetStartTime) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_event_t se = pt_span_new_event(span, "timed_op");
+    ASSERT_NE(se, nullptr);
+
+    pt_span_event_set_start_time_ms(se, 1700000000000LL);
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(se);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, GetSpanEventReturnsHandle) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_event_t created = pt_span_new_event(span, "sub_op");
+    ASSERT_NE(created, nullptr);
+
+    pt_span_event_t fetched = pt_span_get_event(span);
+    ASSERT_NE(fetched, nullptr);
+
+    // Both handles refer to the same underlying event.
+    EXPECT_EQ(pt_span_event_get_annotations(created) != nullptr, true);
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(fetched);
+    pt_span_event_destroy(created);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+// ============================================================================
+// 9. Span event error recording
+// ============================================================================
+
+TEST_F(TracerCApiTest, SpanEventSetError) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_event_t se = pt_span_new_event(span, "failing_op");
+    ASSERT_NE(se, nullptr);
+
+    pt_span_event_set_error(se, "connection refused");
+    pt_span_event_set_error_named(se, "IOError", "connection refused");
+
+    pt_callstack_reader_t cs_reader;
+    cs_reader.userdata  = const_cast<Frame*>(kTestFrames);
+    cs_reader.for_each  = callstack_foreach;
+    pt_span_event_set_error_with_callstack(se, "IOError", "connection refused", &cs_reader);
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(se);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, SpanEventSetErrorWithNullCallstack) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_event_t se = pt_span_new_event(span, "failing_op");
+    ASSERT_NE(se, nullptr);
+
+    EXPECT_NO_FATAL_FAILURE(
+        pt_span_event_set_error_with_callstack(se, "Err", "msg", nullptr));
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(se);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+// ============================================================================
+// 10. Annotation operations
+// ============================================================================
+
+TEST_F(TracerCApiTest, SpanAnnotationsAllTypes) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_annotation_t anno = pt_span_get_annotations(span);
+    ASSERT_NE(anno, nullptr);
+
+    // int
+    pt_annotation_append_int(anno, PT_ANNOTATION_HTTP_STATUS_CODE, 200);
+    // long
+    pt_annotation_append_long(anno, PT_ANNOTATION_API, 99999LL);
+    // string
+    pt_annotation_append_string(anno, PT_ANNOTATION_HTTP_URL, "http://example.com/api");
+    // string+string
+    pt_annotation_append_string_string(anno, PT_ANNOTATION_HTTP_REQUEST_HEADER,
+                                       "X-Custom", "value");
+    // int+string+string
+    pt_annotation_append_int_string_string(anno, PT_ANNOTATION_HTTP_PROXY_HEADER,
+                                           1, "proxy", "addr");
+    // bytes+string+string
+    unsigned char uid[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    pt_annotation_append_bytes_string_string(anno, PT_ANNOTATION_SQL_UID,
+                                             uid, 4,
+                                             "SELECT 1", "");
+    // long+int+int+byte+byte+string
+    pt_annotation_append_long_int_int_byte_byte_string(
+        anno, PT_ANNOTATION_HTTP_PROXY_HEADER,
+        /*l=*/12345678L, /*i1=*/8080, /*i2=*/0, /*b1=*/1, /*b2=*/0,
+        "endpoint");
+
+    pt_annotation_destroy(anno);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, SpanEventAnnotationsAllTypes) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_event_t se   = pt_span_new_event(span, "event");
+    ASSERT_NE(se, nullptr);
+
+    pt_annotation_t anno = pt_span_event_get_annotations(se);
+    ASSERT_NE(anno, nullptr);
+
+    pt_annotation_append_int(anno, PT_ANNOTATION_HTTP_STATUS_CODE, 404);
+    pt_annotation_append_string(anno, PT_ANNOTATION_HTTP_URL, "http://example.com/");
+
+    pt_annotation_destroy(anno);
+    pt_span_end_event(span);
+    pt_span_event_destroy(se);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, AnnotationDestroyIsSafeToCallMultipleTimes) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_annotation_t a1 = pt_span_get_annotations(span);
+    pt_annotation_t a2 = pt_span_get_annotations(span);
+    ASSERT_NE(a1, nullptr);
+    ASSERT_NE(a2, nullptr);
+
+    pt_annotation_destroy(a1);
+    pt_annotation_destroy(a2);
+
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+// ============================================================================
+// 11. Header reader with ForEach
+// ============================================================================
+
+TEST_F(TracerCApiTest, SpanRecordHeaderWithForEach) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    HeaderMap req_headers;
+    req_headers["Content-Type"]   = "application/json";
+    req_headers["X-Request-Id"]   = "abc-123";
+    req_headers["Authorization"]  = "Bearer token";
+
+    pt_header_reader_t reader{&req_headers, hmap_get, hmap_foreach};
+    pt_span_record_header(span, PT_HTTP_REQUEST, &reader);
+
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, SpanEventRecordHeaderWithForEach) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_event_t se = pt_span_new_event(span, "http_call");
+    ASSERT_NE(se, nullptr);
+
+    HeaderMap resp_headers;
+    resp_headers["Content-Type"] = "application/json";
+    resp_headers["X-Trace-Id"]   = "trace-xyz";
+
+    pt_header_reader_t reader{&resp_headers, hmap_get, hmap_foreach};
+    pt_span_event_record_header(se, PT_HTTP_RESPONSE, &reader);
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(se);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, ForEachStopsEarlyOnNonZeroReturn) {
+    // Verify that the ForEach callback honours the "stop" return value.
+    HeaderMap headers;
+    headers["A"] = "1";
+    headers["B"] = "2";
+    headers["C"] = "3";
+
+    struct Ctx { int count; };
+    Ctx ctx{0};
+
+    auto stop_after_one = [](const char*, const char*, void* ud) -> int {
+        auto* c = static_cast<Ctx*>(ud);
+        c->count++;
+        return 1;  // stop immediately after the first entry
+    };
+
+    hmap_foreach(&headers, stop_after_one, &ctx);
+    EXPECT_EQ(ctx.count, 1);
+}
+
+// ============================================================================
+// 12. Callstack reader callback
+// ============================================================================
+
+TEST_F(TracerCApiTest, CallstackReaderIteratesFrames) {
+    struct Ctx { std::vector<std::string> fns; };
+    Ctx ctx;
+
+    pt_callstack_reader_t cs_reader;
+    cs_reader.userdata = const_cast<Frame*>(kTestFrames);
+    cs_reader.for_each = callstack_foreach;
+
+    // Drive the iteration manually to verify the callback receives correct data.
+    cs_reader.for_each(
+        cs_reader.userdata,
+        [](const char* mod, const char* fn, const char* file, int line, void* ud) {
+            static_cast<Ctx*>(ud)->fns.push_back(fn);
+            (void)mod; (void)file; (void)line;
+        },
+        &ctx);
+
+    ASSERT_EQ(ctx.fns.size(), 2u);
+    EXPECT_EQ(ctx.fns[0], "foo::bar()");
+    EXPECT_EQ(ctx.fns[1], "foo::entry()");
+}
+
+// ============================================================================
+// 13. Async span
+// ============================================================================
+
+TEST_F(TracerCApiTest, NewAsyncSpan) {
+    pt_span_t parent = pt_agent_new_span(agent_, "parent", "/rpc");
+    ASSERT_NE(parent, nullptr);
+
+    pt_span_t async_span = pt_span_new_async_span(parent, "bg_task");
+    ASSERT_NE(async_span, nullptr);
+
+    pt_span_end(async_span);
+    pt_span_destroy(async_span);
+
+    pt_span_end(parent);
+    pt_span_destroy(parent);
+}
+
+// ============================================================================
+// 14. HTTP helper functions
+// ============================================================================
+
+TEST_F(TracerCApiTest, TraceHttpServerRequest) {
+    pt_span_t span = pt_agent_new_span(agent_, "GET /api", "/api");
+    ASSERT_NE(span, nullptr);
+
+    HeaderMap req_headers;
+    req_headers["Content-Type"] = "application/json";
+    req_headers["User-Agent"]   = "test-client/1.0";
+
+    pt_header_reader_t reader{&req_headers, hmap_get, hmap_foreach};
+
+    EXPECT_NO_FATAL_FAILURE(
+        pt_trace_http_server_request(span, "192.168.1.1", "api.example.com", &reader));
+
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, TraceHttpServerRequestWithCookie) {
+    pt_span_t span = pt_agent_new_span(agent_, "GET /page", "/page");
+    ASSERT_NE(span, nullptr);
+
+    HeaderMap req_headers;
+    req_headers["Accept"] = "text/html";
+
+    HeaderMap cookies;
+    cookies["session"] = "abc123";
+    cookies["pref"]    = "dark";
+
+    pt_header_reader_t req_reader{&req_headers, hmap_get, hmap_foreach};
+    pt_header_reader_t cookie_reader{&cookies, hmap_get, hmap_foreach};
+
+    EXPECT_NO_FATAL_FAILURE(
+        pt_trace_http_server_request_with_cookie(
+            span, "10.0.0.1", "www.example.com",
+            &req_reader, &cookie_reader));
+
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, TraceHttpServerResponse) {
+    pt_span_t span = pt_agent_new_span(agent_, "GET /api", "/api");
+    ASSERT_NE(span, nullptr);
+
+    HeaderMap resp_headers;
+    resp_headers["Content-Type"]   = "application/json";
+    resp_headers["Content-Length"] = "128";
+
+    pt_header_reader_t reader{&resp_headers, hmap_get, hmap_foreach};
+
+    EXPECT_NO_FATAL_FAILURE(
+        pt_trace_http_server_response(span, "/api/v1/*", "GET", 200, &reader));
+
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, TraceHttpClientRequest) {
+    pt_span_t span = pt_agent_new_span(agent_, "outer", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_event_t se = pt_span_new_event_with_type(span, "http_out",
+                                                      PT_SERVICE_TYPE_CPP_HTTP_CLIENT);
+    ASSERT_NE(se, nullptr);
+
+    HeaderMap out_headers;
+    pt_header_reader_t reader{&out_headers, hmap_get, hmap_foreach};
+
+    EXPECT_NO_FATAL_FAILURE(
+        pt_trace_http_client_request(se, "downstream.svc:8080",
+                                     "http://downstream.svc:8080/api", &reader));
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(se);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, TraceHttpClientRequestWithCookie) {
+    pt_span_t span = pt_agent_new_span(agent_, "outer", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_event_t se = pt_span_new_event_with_type(span, "http_out",
+                                                      PT_SERVICE_TYPE_CPP_HTTP_CLIENT);
+    ASSERT_NE(se, nullptr);
+
+    HeaderMap req_headers;
+    HeaderMap cookie_headers;
+    cookie_headers["auth"] = "tok";
+
+    pt_header_reader_t req_reader{&req_headers, hmap_get, hmap_foreach};
+    pt_header_reader_t cookie_reader{&cookie_headers, hmap_get, hmap_foreach};
+
+    EXPECT_NO_FATAL_FAILURE(
+        pt_trace_http_client_request_with_cookie(
+            se, "downstream.svc:8080", "http://downstream.svc:8080/api",
+            &req_reader, &cookie_reader));
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(se);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+TEST_F(TracerCApiTest, TraceHttpClientResponse) {
+    pt_span_t span = pt_agent_new_span(agent_, "outer", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    pt_span_event_t se = pt_span_new_event_with_type(span, "http_out",
+                                                      PT_SERVICE_TYPE_CPP_HTTP_CLIENT);
+    ASSERT_NE(se, nullptr);
+
+    HeaderMap resp_headers;
+    resp_headers["X-Response-Time"] = "42ms";
+
+    pt_header_reader_t reader{&resp_headers, hmap_get, hmap_foreach};
+
+    EXPECT_NO_FATAL_FAILURE(
+        pt_trace_http_client_response(se, 200, &reader));
+
+    pt_span_end_event(span);
+    pt_span_event_destroy(se);
+    pt_span_end(span);
+    pt_span_destroy(span);
+}
+
+// ============================================================================
+// 15. Logging injection
+// ============================================================================
+
+TEST_F(TracerCApiTest, SetLoggingWritesToCarrier) {
+    pt_span_t span = pt_agent_new_span(agent_, "op", "/rpc");
+    ASSERT_NE(span, nullptr);
+
+    HeaderMap mdc;
+    pt_context_writer_t writer{&mdc, hmap_set};
+    pt_span_set_logging(span, &writer);
+
+    // At minimum the span ID should have been injected into the MDC map.
+    EXPECT_FALSE(mdc.empty());
+
+    pt_span_end(span);
+    pt_span_destroy(span);
+}


### PR DESCRIPTION
## Summary
Makes the Pinpoint C++ agent usable from plain C applications by
introducing a pure-C public header alongside the existing C++ header.

Closes #9.

## What's changed

- **`include/pinpoint/tracer_c.h`** — pure-C public API (C-linkage
  declarations, opaque `pt_*_t` handles, callback-based carriers,
  `int64_t` timestamps instead of `std::chrono`).
- **`src/tracer_c.cpp`** — C++ bridge. Stack-allocated adapter classes
  (`CContextReader`, `CHeaderReader`, `CContextWriter`,
  `CCallstackReader`) translate C callback structs into the existing
  C++ virtual interfaces without any extra heap allocation.
- **`test/test_tracer_c.cpp`** — 39 GoogleTest cases across constants,
  null-handle safety, agent/span/event/annotation lifecycle, context
  propagation, header ForEach, callstack reader, async span, and all
  HTTP helper functions.
- **`example/httplib_c.{h,cpp}`** — thin C wrapper around cpp-httplib
  (server + client + mutable headers). Accessor signatures are chosen
  to match `pt_reader_get_fn`/`pt_header_for_each_fn`/`pt_writer_set_fn`
  exactly so that `pt_header_reader_t` / `pt_context_writer_t` can be
  constructed directly from httplib handles with zero adapter code.
- **`example/http_server_c.c`** / **`example/tutorial_c.c`** — pure-C
  ports of the existing C++ examples.
- **CMakeLists.txt / BUILD.bazel / 3rd_party/BUILD / example/BUILD /
  test/BUILD** — register the new sources in both build systems.

## Reviewer notes

- No behavioural changes to the existing C++ API — only additions.
- The handles are `shared_ptr` wrappers, so lifetime is safe across
  async spans and `pt_span_get_event()`.
- Tutorial / http_server C examples mirror the C++ originals 1:1,
  including sleep durations, randomised sample data and the
  upstream/downstream port pair (8080 ↔ 8090).

## Test plan
- [x] CMake: `cmake --build build --target test_tracer_c` → builds clean
- [x] Tests: 39/39 pass (`ctest -R test_tracer_c`)
- [x] CMake: `http_server_c` and `tutorial_c` build and serve HTTP 200
- [x] Bazel: `bazel query` / `bazel build --nobuild` resolve & analyze
      the new targets successfully (full compile blocked by a pre-existing
      macOS/abseil environment issue that also affects `//example:http_server`)