### PR TITLE
[#69] Align SQL normalizer with Java reference

### DIFF
--- a/src/sql.cpp
+++ b/src/sql.cpp
@@ -43,7 +43,11 @@ namespace pinpoint {
         };
         
         State state = State::Normal;
-        
+        // Tracks whether the next digit begins a numeric literal. Mirrors the Java
+        // ParserContext.numberTokenStartEnable flag: a digit that follows an identifier
+        // character (e.g. "col1") is part of the identifier, not a literal.
+        bool number_token_start_enable = true;
+
         for (size_t i = 0; i < sql_length; ++i) {
             char c = sql[i];
             char next_c = (i + 1 < sql_length) ? sql[i + 1] : '\0';
@@ -70,14 +74,26 @@ namespace pinpoint {
                     
                     // Handle numeric literals
                     // Check for digit, or minus sign followed by digit
-                    if (std::isdigit(static_cast<unsigned char>(c)) 
-                        || (c == '-' && next_c != '\0' && std::isdigit(static_cast<unsigned char>(next_c)))) {
+                    const bool is_negative_number = (c == '-' && next_c != '\0'
+                        && std::isdigit(static_cast<unsigned char>(next_c)));
+                    if (std::isdigit(static_cast<unsigned char>(c))) {
+                        if (number_token_start_enable) {
+                            i = handleNumericLiteral(sql, sql_length, i, result);
+                            continue;
+                        }
+                        // Digit is part of an identifier (e.g. the '1' in "col1"); keep it
+                        // as-is and leave the flag unchanged, matching the Java number case.
+                        result.normalized_sql += c;
+                        break;
+                    }
+                    if (is_negative_number) {
                         i = handleNumericLiteral(sql, sql_length, i, result);
                         continue;
                     }
-                    
+
                     // Regular character
                     result.normalized_sql += c;
+                    number_token_start_enable = updateNumberTokenStartEnable(c, next_c, number_token_start_enable);
                     break;
                 }
                 
@@ -148,11 +164,19 @@ namespace pinpoint {
                 }
             }
 
-            // Add to parameters
+            // Add to parameters. The ',' separator delimits parameters on the collector
+            // side, so any comma inside the captured value must be escaped as ",,".
+            // Mirrors Java ParameterBuilder.appendSeparatorCheck.
             if (result.param_index > 0) {
                 result.parameters += ',';
             }
-            result.parameters += content;
+            for (char ch : content) {
+                if (ch == ',') {
+                    result.parameters += ",,";
+                } else {
+                    result.parameters += ch;
+                }
+            }
 
             // Add placeholder to SQL
             result.normalized_sql += quote_char;
@@ -210,6 +234,32 @@ namespace pinpoint {
         
         result.param_index++;
         return current_idx - 1; // Back up one since the loop will increment
+    }
+
+    bool SqlNormalizer::updateNumberTokenStartEnable(char c, char next_c, bool current) {
+        switch (c) {
+            // Whitespace
+            case ' ': case '\t': case '\n': case '\r':
+            // Operators
+            case '*': case '+': case '%': case '=': case '<': case '>':
+            case '&': case '|': case '^': case '~': case '!':
+            // Separators and unary operators ('-' / '/' reach here only when they are
+            // not the start of a comment or a negative numeric literal)
+            case '(': case ')': case ',': case ';': case '-': case '/':
+                return true;
+            case '$':
+                // A digit following a positional placeholder ($1, $2, ...) is not a literal.
+                if (next_c >= '0' && next_c <= '9') {
+                    return false;
+                }
+                return current;
+            case '.': case '_': case '@': case ':':
+                return false;
+            default:
+                // Letters begin an identifier (no number token); any other character may
+                // precede a numeric literal.
+                return (c < 'a' || c > 'z') && (c < 'A' || c > 'Z');
+        }
     }
 
 } // namespace pinpoint

--- a/src/sql.h
+++ b/src/sql.h
@@ -97,5 +97,18 @@ namespace pinpoint {
         * @return Index of the last character of the numeric literal
         */
         static size_t handleNumericLiteral(std::string_view sql, size_t sql_length, size_t start_idx, SqlNormalizeResult& result);
+
+        /**
+        * Recompute the "number token start enabled" flag after processing a regular
+        * character, mirroring the Java ParserContext.numberTokenStartEnable tracking.
+        * A digit is only treated as a numeric literal when this flag is enabled, so a
+        * digit that follows an identifier character (e.g. the '1' in "col1") is left alone.
+        *
+        * @param c Character just appended to the normalized SQL
+        * @param next_c Following character (used for the '$' positional placeholder case)
+        * @param current Current flag value (returned unchanged for the '$' non-digit case)
+        * @return New flag value
+        */
+        static bool updateNumberTokenStartEnable(char c, char next_c, bool current);
     };
 } // namespace pinpoint

--- a/test/test_sql.cpp
+++ b/test/test_sql.cpp
@@ -353,11 +353,22 @@ TEST_F(SqlTest, MinusBetweenNumbersTest) {
     EXPECT_TRUE(result2.normalized_sql.find("FROM t") != std::string::npos);
 }
 
-// Test string parameter containing comma (ambiguous with parameter separator)
+// Test string parameter containing comma (ambiguous with parameter separator).
+// Commas inside a string value are escaped as ",," so they are not confused with the
+// ',' separator between parameters (matches Java ParameterBuilder.appendSeparatorCheck).
 TEST_F(SqlTest, StringWithCommaParameterTest) {
     auto result = normalizer_->normalize("SELECT * FROM t WHERE name = 'Doe, John'");
     EXPECT_EQ(result.normalized_sql, "SELECT * FROM t WHERE name = '0$'");
-    EXPECT_EQ(result.parameters, "Doe, John");
+    EXPECT_EQ(result.parameters, "Doe,, John");
+}
+
+// Test multiple string parameters where one contains a comma. The embedded comma is
+// escaped (",,") while the separator between the two parameters stays a single ','.
+TEST_F(SqlTest, StringWithCommaAmongMultipleParametersTest) {
+    auto result = normalizer_->normalize(
+        "INSERT INTO t (a, b) VALUES ('Doe, John', 'plain')");
+    EXPECT_EQ(result.normalized_sql, "INSERT INTO t (a, b) VALUES ('0$', '1$')");
+    EXPECT_EQ(result.parameters, "Doe,, John,plain");
 }
 
 // Test consecutive block comments
@@ -395,17 +406,26 @@ TEST_F(SqlTest, LineCommentCROnlyTest) {
     EXPECT_EQ(result.parameters, "");
 }
 
-// Test numbers embedded in identifiers (e.g., table1, col2)
+// Test numbers embedded in identifiers (e.g., table1, col2). A digit that follows an
+// identifier character is part of the identifier and is NOT treated as a numeric literal
+// (matches Java ParserContext.numberTokenStartEnable).
 TEST_F(SqlTest, NumbersInIdentifiersTest) {
-    // Numbers preceded by letters are still just characters in the normal flow;
-    // the normalizer treats standalone digits as numeric literals
     auto result = normalizer_->normalize("SELECT col1 FROM table2 WHERE id = 5");
-    // col1 and table2: the '1' and '2' are digits that will be captured as numeric literals
-    // This documents the current behavior
-    EXPECT_TRUE(result.normalized_sql.find("= 0#") != std::string::npos ||
-                result.normalized_sql.find("= ") != std::string::npos);
-    // The parameter 5 should be captured
-    EXPECT_TRUE(result.parameters.find("5") != std::string::npos);
+    // col1 and table2 are left intact; only the standalone 5 is a literal.
+    EXPECT_EQ(result.normalized_sql, "SELECT col1 FROM table2 WHERE id = 0#");
+    EXPECT_EQ(result.parameters, "5");
+}
+
+// Test identifiers ending in a digit with no standalone numeric literal present.
+TEST_F(SqlTest, IdentifierEndingInDigitTest) {
+    auto result = normalizer_->normalize("SELECT col1 FROM t1");
+    EXPECT_EQ(result.normalized_sql, "SELECT col1 FROM t1");
+    EXPECT_EQ(result.parameters, "");
+
+    // Multi-digit suffix and a digit-only-after-letter identifier.
+    result = normalizer_->normalize("SELECT a1, b22, c3 FROM t9");
+    EXPECT_EQ(result.normalized_sql, "SELECT a1, b22, c3 FROM t9");
+    EXPECT_EQ(result.parameters, "");
 }
 
 // Test truncation cutting through a string literal


### PR DESCRIPTION
Closes #69

Fixes two divergences in `SqlNormalizer::normalize()` (`src/sql.cpp`) from the Java reference implementation (commons-profiler `ParserContext` / `ParameterBuilder`).

## Changes

### 1. Comma escaping in string-literal parameters
`handleStringLiteral()` now escapes commas inside a captured string value as `,,`, so an embedded comma is not confused with the `,` separator between parameters on the collector side. Mirrors `ParameterBuilder.appendSeparatorCheck`.

- `'Doe, John'` → parameter `Doe,, John` (was `Doe, John`)

### 2. Identifier digit misdetection (`numberTokenStartEnable`)
Introduced a `number_token_start_enable` flag tracked through the Normal state, mirroring the Java `ParserContext`. A digit is only treated as a numeric literal when the flag is enabled; a digit following an identifier character is left intact.

- `SELECT col1 FROM table2 WHERE id = 5` → `SELECT col1 FROM table2 WHERE id = 0#`, parameters `5` (previously `col1` became `col0#`)

The existing shared `param_index` / `#`/`$` placeholder scheme and negative-number handling are unchanged.

## Tests
- Updated `StringWithCommaParameterTest` and `NumbersInIdentifiersTest` to assert the Java-parity behavior.
- Added `StringWithCommaAmongMultipleParametersTest` and `IdentifierEndingInDigitTest`.
- Verified the full `test_sql` suite (50/50) passing by compiling `sql.cpp` + `test_sql.cpp` against gtest.