### PR TITLE
[#73] Recognize // single-line comments in SQL normalizer

### DIFF
--- a/src/sql.cpp
+++ b/src/sql.cpp
@@ -65,7 +65,12 @@ namespace pinpoint {
                         i++; // Skip next '*'
                         continue;
                     }
-                    
+                    if (c == '/' && next_c == '/') {
+                        state = State::InLineComment;
+                        i++; // Skip next '/'
+                        continue;
+                    }
+
                     // Handle start of string literals
                     if (isQuoteChar(c)) {
                         i = handleStringLiteral(sql, sql_length, i + 1, c, result);

--- a/test/test_sql.cpp
+++ b/test/test_sql.cpp
@@ -128,6 +128,20 @@ TEST_F(SqlTest, BlockCommentRemovalTest) {
     EXPECT_EQ(result.parameters, "");
 }
 
+// Test // single-line comment removal (matches Java agent behavior)
+TEST_F(SqlTest, SlashSlashLineCommentRemovalTest) {
+    auto result = normalizer_->normalize("SELECT * FROM t // trailing comment\nWHERE a=1");
+    EXPECT_EQ(result.normalized_sql, "SELECT * FROM t \nWHERE a=0#");
+    EXPECT_EQ(result.parameters, "1");
+}
+
+// Test that a lone '/' (division operator) is preserved as a normal character
+TEST_F(SqlTest, DivisionOperatorPreservedTest) {
+    auto result = normalizer_->normalize("SELECT a/b FROM t");
+    EXPECT_EQ(result.normalized_sql, "SELECT a/b FROM t");
+    EXPECT_EQ(result.parameters, "");
+}
+
 // Test mixed comments
 TEST_F(SqlTest, MixedCommentsTest) {
     auto result = normalizer_->normalize("SELECT * /* block */ FROM users -- line comment");


### PR DESCRIPTION
## Summary

`SqlNormalizer::normalize()` in `src/sql.cpp` did not recognize `//` single-line comments, while the reference Java agent (`ParserContext.parse`) does. This adds a `//` line-comment case to the `State::Normal` branch, mirroring the existing `--` handling.

Closes #73

## Changes

- `src/sql.cpp`: add `c == '/' && next_c == '/'` case that transitions to `State::InLineComment` and skips the second `/`. The existing `InLineComment` handler already terminates on `\n`/`\r`.
  - A lone `/` (division operator) and `/* */` block comments are unaffected since they branch on the next character.
- `test/test_sql.cpp`: add tests
  - `SlashSlashLineCommentRemovalTest`: `SELECT * FROM t // trailing comment\nWHERE a=1` -> comment removed, rest normalized.
  - `DivisionOperatorPreservedTest`: `SELECT a/b FROM t` preserved unchanged.

## Testing

All 52 SQL normalizer tests pass (including existing `--` and `/* */` cases plus the two new ones).