### PR TITLE
[#75] Align SQL normalizer with Java agent

### DIFF
--- a/src/sql.cpp
+++ b/src/sql.cpp
@@ -17,11 +17,61 @@
 #include "sql.h"
 #include <algorithm>
 #include <cctype>
+#include <limits>
 
 namespace pinpoint {
 
-    SqlNormalizer::SqlNormalizer(size_t max_sql_length) 
-        : max_sql_length_(max_sql_length) {
+    namespace {
+        constexpr char kNumberReplace = '#';
+        constexpr char kSymbolReplace = '$';
+
+        char lookAhead1(std::string_view sql, size_t index) {
+            ++index;
+            return index < sql.length() ? sql[index] : '\0';
+        }
+
+        bool isDigit(char c) {
+            return std::isdigit(static_cast<unsigned char>(c)) != 0;
+        }
+
+        void appendParameterSeparator(SqlNormalizeResult& result) {
+            if (!result.parameters.empty()) {
+                result.parameters += ',';
+            }
+        }
+
+        void appendParameterChar(SqlNormalizeResult& result, char ch) {
+            if (ch == ',') {
+                result.parameters += ",,";
+            } else {
+                result.parameters += ch;
+            }
+        }
+
+        bool parseIndex(std::string_view text, size_t& index) {
+            if (text.empty()) {
+                return false;
+            }
+
+            size_t value = 0;
+            for (char ch : text) {
+                if (!isDigit(ch)) {
+                    return false;
+                }
+                const size_t digit = static_cast<size_t>(ch - '0');
+                if (value > (std::numeric_limits<size_t>::max() - digit) / 10) {
+                    return false;
+                }
+                value = (value * 10) + digit;
+            }
+
+            index = value;
+            return true;
+        }
+    } // namespace
+
+    SqlNormalizer::SqlNormalizer(size_t max_sql_length, bool remove_comments)
+        : max_sql_length_(max_sql_length), remove_comments_(remove_comments) {
     }
 
     SqlNormalizeResult SqlNormalizer::normalize(std::string_view sql) const {
@@ -30,19 +80,12 @@ namespace pinpoint {
             return result;
         }
         
-        // Limit SQL length to prevent memory issues
-        const size_t sql_length = std::min(sql.length(), max_sql_length_);
+        // Limit SQL length to prevent memory issues.
+        sql = sql.substr(0, std::min(sql.length(), max_sql_length_));
+        const size_t sql_length = sql.length();
         result.normalized_sql.reserve(sql_length);
         result.parameters.reserve(64);
-        
-        enum class State {
-            Normal,
-            InLineComment,
-            InBlockComment,
-            InBlockCommentEnd
-        };
-        
-        State state = State::Normal;
+
         // Tracks whether the next digit begins a numeric literal. Mirrors the Java
         // ParserContext.numberTokenStartEnable flag: a digit that follows an identifier
         // character (e.g. "col1") is part of the identifier, not a literal.
@@ -50,195 +93,274 @@ namespace pinpoint {
 
         for (size_t i = 0; i < sql_length; ++i) {
             char c = sql[i];
-            char next_c = (i + 1 < sql_length) ? sql[i + 1] : '\0';
-            
-            switch (state) {
-                case State::Normal: {
-                    // Handle start of comments
-                    if (c == '-' && next_c == '-') {
-                        state = State::InLineComment;
-                        i++; // Skip next '-'
-                        continue;
-                    }
-                    if (c == '/' && next_c == '*') {
-                        state = State::InBlockComment;
-                        i++; // Skip next '*'
-                        continue;
-                    }
-                    if (c == '/' && next_c == '/') {
-                        state = State::InLineComment;
-                        i++; // Skip next '/'
-                        continue;
-                    }
+            char next_c = lookAhead1(sql, i);
 
-                    // Handle start of string literals
-                    if (isQuoteChar(c)) {
-                        i = handleStringLiteral(sql, sql_length, i + 1, c, result);
-                        continue;
-                    }
-                    
-                    // Handle numeric literals
-                    // Check for digit, or minus sign followed by digit
-                    const bool is_negative_number = (c == '-' && next_c != '\0'
-                        && std::isdigit(static_cast<unsigned char>(next_c)));
-                    if (std::isdigit(static_cast<unsigned char>(c))) {
-                        if (number_token_start_enable) {
-                            i = handleNumericLiteral(sql, sql_length, i, result);
-                            continue;
-                        }
-                        // Digit is part of an identifier (e.g. the '1' in "col1"); keep it
-                        // as-is and leave the flag unchanged, matching the Java number case.
+            switch (c) {
+                case '/':
+                    if (next_c == '*') {
+                        i = readComment(sql, sql_length, i, "/*", "*/",
+                            remove_comments_ ? nullptr : &result.normalized_sql);
+                    } else if (next_c == '/') {
+                        i = readComment(sql, sql_length, i, "//", "\n",
+                            remove_comments_ ? nullptr : &result.normalized_sql);
+                    } else {
+                        number_token_start_enable = true;
                         result.normalized_sql += c;
-                        break;
                     }
-                    if (is_negative_number) {
+                    break;
+
+                case '-':
+                    if (next_c == '-') {
+                        i = readComment(sql, sql_length, i, "--", "\n",
+                            remove_comments_ ? nullptr : &result.normalized_sql);
+                    } else {
+                        number_token_start_enable = true;
+                        result.normalized_sql += c;
+                    }
+                    break;
+
+                case '\'':
+                    i = handleStringLiteral(sql, sql_length, i, c, result);
+                    break;
+
+                case '0': case '1': case '2': case '3': case '4':
+                case '5': case '6': case '7': case '8': case '9':
+                    if (number_token_start_enable) {
                         i = handleNumericLiteral(sql, sql_length, i, result);
-                        continue;
-                    }
-
-                    // Regular character
-                    result.normalized_sql += c;
-                    number_token_start_enable = updateNumberTokenStartEnable(c, next_c, number_token_start_enable);
-                    break;
-                }
-                
-                case State::InLineComment: {
-                    if (c == '\n' || c == '\r') {
-                        state = State::Normal;
+                    } else {
                         result.normalized_sql += c;
                     }
-                    // Skip all other characters in line comment
                     break;
-                }
-                
-                case State::InBlockComment: {
-                    if (c == '*' && next_c == '/') {
-                        state = State::InBlockCommentEnd;
+
+                case ' ': case '\t': case '\n': case '\r':
+                case '*': case '+': case '%': case '=': case '<': case '>':
+                case '&': case '|': case '^': case '~': case '!':
+                case '(': case ')': case ',': case ';':
+                    number_token_start_enable = true;
+                    result.normalized_sql += c;
+                    break;
+
+                case '$':
+                    if (next_c >= '0' && next_c <= '9') {
+                        number_token_start_enable = false;
                     }
-                    // Skip all characters in block comment
+                    result.normalized_sql += c;
                     break;
-                }
-                
-                case State::InBlockCommentEnd: {
-                    state = State::Normal;
-                    // Add space to replace the comment
-                    result.normalized_sql += ' ';
+
+                case '.': case '_': case '@': case ':':
+                    number_token_start_enable = false;
+                    result.normalized_sql += c;
                     break;
-                }
+
+                default:
+                    number_token_start_enable = updateNumberTokenStartEnable(c, next_c, number_token_start_enable);
+                    result.normalized_sql += c;
+                    break;
             }
         }
-        
+
         return result;
     }
 
-    bool SqlNormalizer::isQuoteChar(char c) {
-        return c == '\'' || c == '"' || c == '`';
-    }
+    std::string SqlNormalizer::combineOutputParams(std::string_view sql, const std::vector<std::string>& output_params) const {
+        if (sql.empty()) {
+            return "";
+        }
 
-    size_t SqlNormalizer::handleStringLiteral(std::string_view sql, size_t sql_length, size_t start_idx, char quote_char, SqlNormalizeResult& result) {
-        size_t current_idx = start_idx;
-        bool closed = false;
-        
-        // Scan for closing quote
-        while (current_idx < sql_length) {
-            if (sql[current_idx] == quote_char) {
-                // Check for escaped quote (e.g. 'don''t')
-                if (current_idx + 1 < sql_length && sql[current_idx + 1] == quote_char) {
-                    current_idx += 2; // Skip both quotes
-                } else {
-                    closed = true;
+        const size_t length = sql.length();
+        std::string normalized;
+        normalized.reserve(length + 16);
+
+        for (size_t i = 0; i < length; ++i) {
+            const char ch = sql[i];
+            switch (ch) {
+                case '/':
+                    if (lookAhead1(sql, i) == '*') {
+                        i = readComment(sql, length, i, "/*", "*/", &normalized);
+                    } else if (lookAhead1(sql, i) == '/') {
+                        i = readComment(sql, length, i, "//", "\n", &normalized);
+                    } else {
+                        normalized += ch;
+                    }
+                    break;
+
+                case '-':
+                    if (lookAhead1(sql, i) == '-') {
+                        i = readComment(sql, length, i, "--", "\n", &normalized);
+                    } else {
+                        normalized += ch;
+                    }
+                    break;
+
+                case '0': case '1': case '2': case '3': case '4':
+                case '5': case '6': case '7': case '8': case '9': {
+                    if (lookAhead1(sql, i) == '\0') {
+                        normalized += ch;
+                        break;
+                    }
+
+                    std::string output_index;
+                    output_index += ch;
+                    ++i;
+
+                    bool token_done = false;
+                    for (; i < length; ++i) {
+                        const char state_ch = sql[i];
+                        if (isDigit(state_ch)) {
+                            if (lookAhead1(sql, i) == '\0') {
+                                output_index += state_ch;
+                                normalized += output_index;
+                                token_done = true;
+                                break;
+                            }
+                            output_index += state_ch;
+                            continue;
+                        }
+
+                        if (state_ch == kNumberReplace || state_ch == kSymbolReplace) {
+                            size_t index = 0;
+                            if (parseIndex(output_index, index) && index < output_params.size()) {
+                                normalized += output_params[index];
+                            } else {
+                                normalized += output_index;
+                                normalized += state_ch;
+                            }
+                            token_done = true;
+                            break;
+                        }
+
+                        normalized += output_index;
+                        --i;
+                        token_done = true;
+                        break;
+                    }
+
+                    if (!token_done) {
+                        normalized += output_index;
+                    }
                     break;
                 }
-            } else {
-                current_idx++;
+
+                default:
+                    normalized += ch;
+                    break;
             }
         }
 
-        if (closed) {
-            // Extract content, handling escaped quotes if necessary
-            std::string content;
-            size_t content_len = current_idx - start_idx;
-            content.reserve(content_len);
-            
-            for (size_t i = start_idx; i < current_idx; ++i) {
-                if (sql[i] == quote_char && i + 1 < current_idx && sql[i + 1] == quote_char) {
-                    content += quote_char;
-                    i++; // Skip escaped char
-                } else {
-                    content += sql[i];
+        return normalized;
+    }
+
+    std::string SqlNormalizer::combineBindValues(std::string_view sql, const std::vector<std::string>& bind_values) const {
+        if (sql.empty() || bind_values.empty()) {
+            return std::string(sql);
+        }
+
+        const size_t length = sql.length();
+        std::string result;
+        result.reserve(length + 16);
+
+        bool in_quotes = false;
+        char quote_char = 0;
+        size_t bind_index = 0;
+
+        for (size_t i = 0; i < length; ++i) {
+            const char ch = sql[i];
+            if (in_quotes) {
+                if ((ch == '\'' || ch == '"') && ch == quote_char) {
+                    if (lookAhead1(sql, i) == quote_char) {
+                        result += ch;
+                        ++i;
+                        continue;
+                    }
+                    in_quotes = false;
+                    quote_char = 0;
                 }
+                result += ch;
+                continue;
             }
 
-            // Add to parameters. The ',' separator delimits parameters on the collector
-            // side, so any comma inside the captured value must be escaped as ",,".
-            // Mirrors Java ParameterBuilder.appendSeparatorCheck.
-            if (result.param_index > 0) {
-                result.parameters += ',';
-            }
-            for (char ch : content) {
-                if (ch == ',') {
-                    result.parameters += ",,";
+            if (ch == '/') {
+                if (lookAhead1(sql, i) == '*') {
+                    i = readComment(sql, length, i, "/*", "*/", &result);
+                } else if (lookAhead1(sql, i) == '/') {
+                    i = readComment(sql, length, i, "//", "\n", &result);
                 } else {
-                    result.parameters += ch;
+                    result += ch;
+                }
+            } else if (ch == '-') {
+                if (lookAhead1(sql, i) == '-') {
+                    i = readComment(sql, length, i, "--", "\n", &result);
+                } else {
+                    result += ch;
+                }
+            } else if (ch == '\'' || ch == '"') {
+                in_quotes = true;
+                quote_char = ch;
+                result += ch;
+            } else if (ch == '?') {
+                if (bind_index < bind_values.size()) {
+                    result += '\'';
+                    result += bind_values[bind_index++];
+                    result += '\'';
+                }
+            } else {
+                result += ch;
+            }
+        }
+
+        return result;
+    }
+
+    size_t SqlNormalizer::handleStringLiteral(std::string_view sql, size_t sql_length, size_t start_idx, char quote_char, SqlNormalizeResult& result) {
+        if (start_idx + 1 < sql_length && sql[start_idx + 1] == quote_char) {
+            result.normalized_sql += quote_char;
+            result.normalized_sql += quote_char;
+            return start_idx + 1;
+        }
+
+        result.normalized_sql += quote_char;
+        appendParameterSeparator(result);
+
+        size_t current_idx = start_idx + 1;
+        for (; current_idx < sql_length; ++current_idx) {
+            const char state_ch = sql[current_idx];
+            if (state_ch == quote_char) {
+                if (current_idx + 1 < sql_length && sql[current_idx + 1] == quote_char) {
+                    ++current_idx;
+                    result.parameters += "''";
+                    continue;
+                } else {
+                    result.normalized_sql += std::to_string(result.param_index);
+                    result.normalized_sql += kSymbolReplace;
+                    result.normalized_sql += quote_char;
+                    ++result.param_index;
+                    break;
                 }
             }
-
-            // Add placeholder to SQL
-            result.normalized_sql += quote_char;
-            result.normalized_sql += std::to_string(result.param_index);
-            result.normalized_sql += '$';
-            result.normalized_sql += quote_char;
-            
-            result.param_index++;
-        } else {
-            // Malformed string - include as is from the opening quote
-            // We only add the opening quote here, the rest will be processed in next iterations
-            // But waiting... if we just add 'quote_char', the loop continues. 
-            // The original logic consumed the whole string.
-            // Let's consume it all as is.
-            result.normalized_sql += quote_char;
-            for (size_t i = start_idx; i < sql_length; ++i) {
-                result.normalized_sql += sql[i];
-            }
-            current_idx = sql_length; // End loop
+            appendParameterChar(result, state_ch);
         }
 
         return current_idx;
     }
 
     size_t SqlNormalizer::handleNumericLiteral(std::string_view sql, size_t sql_length, size_t start_idx, SqlNormalizeResult& result) {
-        size_t current_idx = start_idx;
-        
-        if (sql[current_idx] == '-') {
-            current_idx++;
-        }
-        
-        // Read the entire number (including decimals)
+        appendParameterSeparator(result);
+        result.normalized_sql += std::to_string(result.param_index);
+        result.normalized_sql += kNumberReplace;
+        ++result.param_index;
+
+        size_t current_idx = start_idx + 1;
         while (current_idx < sql_length) {
-            char nc = sql[current_idx];
-            if (std::isdigit(static_cast<unsigned char>(nc)) || nc == '.') {
-                current_idx++;
+            const char state_ch = sql[current_idx];
+            if (isDigit(state_ch) || state_ch == '.' || state_ch == 'E' || state_ch == 'e') {
+                ++current_idx;
             } else {
                 break;
             }
         }
-        
-        // Extract number string
-        std::string number;
-        number.assign(sql.data() + start_idx, current_idx - start_idx);
-        
-        // Add to parameters
-        if (result.param_index > 0) {
-            result.parameters += ',';
-        }
-        result.parameters += number;
 
-        // Add placeholder
-        result.normalized_sql += std::to_string(result.param_index);
-        result.normalized_sql += '#';
-        
-        result.param_index++;
-        return current_idx - 1; // Back up one since the loop will increment
+        result.parameters.append(sql.substr(start_idx, current_idx - start_idx));
+        return current_idx - 1;
     }
 
     bool SqlNormalizer::updateNumberTokenStartEnable(char c, char next_c, bool current) {
@@ -265,6 +387,25 @@ namespace pinpoint {
                 // precede a numeric literal.
                 return (c < 'a' || c > 'z') && (c < 'A' || c > 'Z');
         }
+    }
+
+    size_t SqlNormalizer::readComment(std::string_view sql, size_t sql_length, size_t start_idx, std::string_view first_token,
+        std::string_view end_token, std::string* writer) {
+        const size_t search_start = std::min(start_idx + first_token.length(), sql_length);
+        const size_t end_index = sql.find(end_token, search_start);
+
+        size_t return_idx = sql_length;
+        size_t append_end = sql_length;
+        if (end_index != std::string_view::npos && end_index < sql_length) {
+            return_idx = end_index + end_token.length() - 1;
+            append_end = std::min(return_idx + 1, sql_length);
+        }
+
+        if (writer != nullptr && start_idx < append_end) {
+            writer->append(sql.substr(start_idx, append_end - start_idx));
+        }
+
+        return return_idx;
     }
 
 } // namespace pinpoint

--- a/src/sql.h
+++ b/src/sql.h
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace pinpoint {
 
@@ -25,7 +26,7 @@ namespace pinpoint {
     * SQL normalization result
     */
     struct SqlNormalizeResult {
-        // Normalized SQL with numeric placeholders (1#, 2#, 3#...) and string placeholders ('1$', '2$', '3$'...)
+        // Normalized SQL with numeric placeholders (0#, 1#, 2#...) and string placeholders ('0$', '1$', '2$'...)
         std::string normalized_sql;
         // Extracted numeric literals and string literals in order (comma-separated)
         std::string parameters;
@@ -39,17 +40,18 @@ namespace pinpoint {
     * SQL Normalizer class for APM tracing
     * 
     * This class normalizes SQL queries by:
-    * - Removing numeric literals and replacing with indexed placeholders (1#, 2#, 3#...)
-    * - Removing string literals and replacing with indexed placeholders ('1$', '2$', '3$'...)
-    * - Removing comments
+    * - Removing numeric literals and replacing with indexed placeholders (0#, 1#, 2#...)
+    * - Removing string literals and replacing with indexed placeholders ('0$', '1$', '2$'...)
+    * - Optionally removing comments
     * - Extracting numeric literals and string literals in order (comma-separated)
     */
     class SqlNormalizer {
     public:
         /**
-        * Constructor with optional configuration
+        * Constructor with optional maximum SQL length. Comments are removed by
+        * default, matching the Java agent's default JDBC option.
         */
-        explicit SqlNormalizer(size_t max_sql_length = 2048);
+        explicit SqlNormalizer(size_t max_sql_length = 2048, bool remove_comments = true);
         
         /**
         * Destructor
@@ -64,17 +66,14 @@ namespace pinpoint {
         */
         SqlNormalizeResult normalize(std::string_view sql) const;
 
+        std::string combineOutputParams(std::string_view sql, const std::vector<std::string>& output_params) const;
+
+        std::string combineBindValues(std::string_view sql, const std::vector<std::string>& bind_values) const;
+
     private:
         size_t max_sql_length_;
+        bool remove_comments_;
         
-        /**
-        * Check if character is a quote character
-        * 
-        * @param c Character to check
-        * @return True if quote character
-        */
-        static bool isQuoteChar(char c);
-
         /**
         * Handle string literal
         * 
@@ -110,5 +109,8 @@ namespace pinpoint {
         * @return New flag value
         */
         static bool updateNumberTokenStartEnable(char c, char next_c, bool current);
+
+        static size_t readComment(std::string_view sql, size_t sql_length, size_t start_idx, std::string_view first_token,
+            std::string_view end_token, std::string* writer);
     };
 } // namespace pinpoint

--- a/test/test_sql.cpp
+++ b/test/test_sql.cpp
@@ -17,6 +17,7 @@
 #include "../src/sql.h"
 #include <gtest/gtest.h>
 #include <string>
+#include <vector>
 
 namespace pinpoint {
 
@@ -33,6 +34,56 @@ protected:
 protected:
     std::unique_ptr<SqlNormalizer> normalizer_;
 };
+
+static std::vector<std::string> ParseOutputParameter(std::string_view output_params) {
+    if (output_params.empty()) {
+        return {};
+    }
+
+    std::vector<std::string> result;
+    std::string params;
+    for (size_t index = 0; index < output_params.length(); ++index) {
+        const char ch = output_params[index];
+        if (ch == ',') {
+            const char ahead = (index + 1 < output_params.length()) ? output_params[index + 1] : '\0';
+            if (ahead == ',') {
+                params += ',';
+                ++index;
+            } else {
+                if (ahead == ' ') {
+                    ++index;
+                }
+                result.push_back(params);
+                params.clear();
+            }
+        } else {
+            params += ch;
+        }
+    }
+
+    result.push_back(params);
+    return result;
+}
+
+static void ExpectNormalize(const SqlNormalizer& normalizer, std::string_view sql,
+    std::string_view expected_normalized, std::string_view expected_params = "") {
+    auto result = normalizer.normalize(sql);
+    EXPECT_EQ(result.normalized_sql, expected_normalized);
+    EXPECT_EQ(result.parameters, expected_params);
+}
+
+static void ExpectJavaDefaultNormalize(std::string_view sql, std::string_view expected_normalized,
+    std::string_view expected_params = "") {
+    SqlNormalizer java_default(2048, false);
+    ExpectNormalize(java_default, sql, expected_normalized, expected_params);
+}
+
+static void ExpectJavaCombine(std::string_view original_sql, std::string_view normalized_sql,
+    std::string_view output_params) {
+    SqlNormalizer java_default(2048, false);
+    ExpectNormalize(java_default, original_sql, normalized_sql, output_params);
+    EXPECT_EQ(java_default.combineOutputParams(normalized_sql, ParseOutputParameter(output_params)), original_sql);
+}
 
 // ========== Basic Normalization Tests ==========
 
@@ -66,8 +117,8 @@ TEST_F(SqlTest, NumericParameterReplacementTest) {
 // Test negative numbers
 TEST_F(SqlTest, NegativeNumberParameterTest) {
     auto result = normalizer_->normalize("SELECT * FROM users WHERE balance = -100.50");
-    EXPECT_EQ(result.normalized_sql, "SELECT * FROM users WHERE balance = 0#");
-    EXPECT_EQ(result.parameters, "-100.50");
+    EXPECT_EQ(result.normalized_sql, "SELECT * FROM users WHERE balance = -0#");
+    EXPECT_EQ(result.parameters, "100.50");
 }
 
 // Test decimal numbers
@@ -113,25 +164,25 @@ TEST_F(SqlTest, LineCommentRemovalTest) {
     EXPECT_EQ(result.parameters, "");
     
     result = normalizer_->normalize("SELECT * FROM users -- Comment\nWHERE id = 1");
-    EXPECT_EQ(result.normalized_sql, "SELECT * FROM users \nWHERE id = 0#");
+    EXPECT_EQ(result.normalized_sql, "SELECT * FROM users WHERE id = 0#");
     EXPECT_EQ(result.parameters, "1");
 }
 
 // Test block comment removal
 TEST_F(SqlTest, BlockCommentRemovalTest) {
     auto result = normalizer_->normalize("SELECT * /* This is a block comment */ FROM users");
-    EXPECT_EQ(result.normalized_sql, "SELECT *   FROM users");
+    EXPECT_EQ(result.normalized_sql, "SELECT *  FROM users");
     EXPECT_EQ(result.parameters, "");
     
     result = normalizer_->normalize("SELECT * /* Multi\nline\ncomment */ FROM users");
-    EXPECT_EQ(result.normalized_sql, "SELECT *   FROM users");
+    EXPECT_EQ(result.normalized_sql, "SELECT *  FROM users");
     EXPECT_EQ(result.parameters, "");
 }
 
 // Test // single-line comment removal (matches Java agent behavior)
 TEST_F(SqlTest, SlashSlashLineCommentRemovalTest) {
     auto result = normalizer_->normalize("SELECT * FROM t // trailing comment\nWHERE a=1");
-    EXPECT_EQ(result.normalized_sql, "SELECT * FROM t \nWHERE a=0#");
+    EXPECT_EQ(result.normalized_sql, "SELECT * FROM t WHERE a=0#");
     EXPECT_EQ(result.parameters, "1");
 }
 
@@ -145,14 +196,14 @@ TEST_F(SqlTest, DivisionOperatorPreservedTest) {
 // Test mixed comments
 TEST_F(SqlTest, MixedCommentsTest) {
     auto result = normalizer_->normalize("SELECT * /* block */ FROM users -- line comment");
-    EXPECT_EQ(result.normalized_sql, "SELECT *   FROM users ");
+    EXPECT_EQ(result.normalized_sql, "SELECT *  FROM users ");
     EXPECT_EQ(result.parameters, "");
 }
 
 // Test comments with parameters
 TEST_F(SqlTest, CommentsWithParametersTest) {
     auto result = normalizer_->normalize("SELECT * FROM users /* ignore 123 */ WHERE id = 456 -- ignore :param");
-    EXPECT_EQ(result.normalized_sql, "SELECT * FROM users   WHERE id = 0# ");
+    EXPECT_EQ(result.normalized_sql, "SELECT * FROM users  WHERE id = 0# ");
     EXPECT_EQ(result.parameters, "456");
 }
 
@@ -175,22 +226,18 @@ TEST_F(SqlTest, WhitespacePreservationTest) {
 TEST_F(SqlTest, StringLiteralHandlingTest) {
     auto result = normalizer_->normalize("SELECT * FROM users WHERE name = 'John''s Company'");
     EXPECT_EQ(result.normalized_sql, "SELECT * FROM users WHERE name = '0$'");
-    EXPECT_EQ(result.parameters, "John's Company");
-    
-    result = normalizer_->normalize("SELECT * FROM users WHERE name = \"John's Company\"");
-    EXPECT_EQ(result.normalized_sql, "SELECT * FROM users WHERE name = \"0$\"");
-    EXPECT_EQ(result.parameters, "John's Company");
+    EXPECT_EQ(result.parameters, "John''s Company");
     
     result = normalizer_->normalize("SELECT * FROM users WHERE name = `user_name`");
-    EXPECT_EQ(result.normalized_sql, "SELECT * FROM users WHERE name = `0$`");
-    EXPECT_EQ(result.parameters, "user_name");
+    EXPECT_EQ(result.normalized_sql, "SELECT * FROM users WHERE name = `user_name`");
+    EXPECT_EQ(result.parameters, "");
 }
 
 // Test string literals with escaped quotes (backslash escape not handled, so string ends at backslash)
 TEST_F(SqlTest, EscapedQuotesTest) {
     auto result = normalizer_->normalize("SELECT * FROM users WHERE name = 'John\\'s Company'");
     EXPECT_EQ(result.normalized_sql, "SELECT * FROM users WHERE name = '0$'s Company'");
-    EXPECT_EQ(result.parameters, "John\\");
+    EXPECT_EQ(result.parameters, "John\\,");
 }
 
 // Test string literals with numbers inside (string literal replaced, numbers in string protected)
@@ -254,7 +301,7 @@ TEST_F(SqlTest, VeryLongSqlTest) {
 // Test SQL with only comments
 TEST_F(SqlTest, OnlyCommentsTest) {
     auto result = normalizer_->normalize("/* This is only a comment */");
-    EXPECT_EQ(result.normalized_sql, " ");
+    EXPECT_EQ(result.normalized_sql, "");
     EXPECT_EQ(result.parameters, "");
 }
 
@@ -320,19 +367,19 @@ TEST_F(SqlTest, CustomMaxSqlLengthTest) {
 // Test empty string literal
 TEST_F(SqlTest, EmptyStringLiteralTest) {
     auto result = normalizer_->normalize("SELECT * FROM users WHERE name = ''");
-    EXPECT_EQ(result.normalized_sql, "SELECT * FROM users WHERE name = '0$'");
+    EXPECT_EQ(result.normalized_sql, "SELECT * FROM users WHERE name = ''");
     EXPECT_EQ(result.parameters, "");
 
     result = normalizer_->normalize("INSERT INTO t VALUES ('', 'hello')");
-    EXPECT_EQ(result.normalized_sql, "INSERT INTO t VALUES ('0$', '1$')");
-    EXPECT_EQ(result.parameters, ",hello");
+    EXPECT_EQ(result.normalized_sql, "INSERT INTO t VALUES ('', '0$')");
+    EXPECT_EQ(result.parameters, "hello");
 }
 
-// Test consecutive escaped quotes (e.g., '''' represents a single quote in SQL)
+// Test consecutive empty string literals (matches Java DefaultSqlNormalizer behavior)
 TEST_F(SqlTest, ConsecutiveEscapedQuotesTest) {
     auto result = normalizer_->normalize("SELECT * FROM t WHERE v = ''''");
-    EXPECT_EQ(result.normalized_sql, "SELECT * FROM t WHERE v = '0$'");
-    EXPECT_EQ(result.parameters, "'");
+    EXPECT_EQ(result.normalized_sql, "SELECT * FROM t WHERE v = ''''");
+    EXPECT_EQ(result.parameters, "");
 }
 
 // Test unclosed block comment
@@ -360,11 +407,12 @@ TEST_F(SqlTest, SubtractionOperatorTest) {
 // Test minus between two numbers
 TEST_F(SqlTest, MinusBetweenNumbersTest) {
     auto result = normalizer_->normalize("SELECT 10 - 3 FROM t");
-    // 10 is a number, then " - " then 3. The minus before 3 is preceded by space and followed by digit,
-    // so it may be treated as negative number -3
+    EXPECT_EQ(result.normalized_sql, "SELECT 0# - 1# FROM t");
+    EXPECT_EQ(result.parameters, "10,3");
+
     auto result2 = normalizer_->normalize("SELECT 10 -3 FROM t");
-    // When minus is directly attached to digit, it's ambiguous
-    EXPECT_TRUE(result2.normalized_sql.find("FROM t") != std::string::npos);
+    EXPECT_EQ(result2.normalized_sql, "SELECT 0# -1# FROM t");
+    EXPECT_EQ(result2.parameters, "10,3");
 }
 
 // Test string parameter containing comma (ambiguous with parameter separator).
@@ -388,14 +436,14 @@ TEST_F(SqlTest, StringWithCommaAmongMultipleParametersTest) {
 // Test consecutive block comments
 TEST_F(SqlTest, ConsecutiveBlockCommentsTest) {
     auto result = normalizer_->normalize("SELECT /* c1 */ * /* c2 */ FROM users");
-    EXPECT_EQ(result.normalized_sql, "SELECT   *   FROM users");
+    EXPECT_EQ(result.normalized_sql, "SELECT  *  FROM users");
     EXPECT_EQ(result.parameters, "");
 }
 
 // Test block comment immediately followed by string literal
 TEST_F(SqlTest, BlockCommentFollowedByStringTest) {
     auto result = normalizer_->normalize("SELECT /* comment */'hello' FROM t");
-    EXPECT_EQ(result.normalized_sql, "SELECT  '0$' FROM t");
+    EXPECT_EQ(result.normalized_sql, "SELECT '0$' FROM t");
     EXPECT_EQ(result.parameters, "hello");
 }
 
@@ -409,14 +457,14 @@ TEST_F(SqlTest, NumberAtEndOfSqlTest) {
 // Test line comment with \r\n line endings
 TEST_F(SqlTest, LineCommentCRLFTest) {
     auto result = normalizer_->normalize("SELECT * -- comment\r\nFROM users");
-    EXPECT_EQ(result.normalized_sql, "SELECT * \r\nFROM users");
+    EXPECT_EQ(result.normalized_sql, "SELECT * FROM users");
     EXPECT_EQ(result.parameters, "");
 }
 
 // Test line comment with only \r (carriage return)
 TEST_F(SqlTest, LineCommentCROnlyTest) {
     auto result = normalizer_->normalize("SELECT * -- comment\rFROM users");
-    EXPECT_EQ(result.normalized_sql, "SELECT * \rFROM users");
+    EXPECT_EQ(result.normalized_sql, "SELECT * ");
     EXPECT_EQ(result.parameters, "");
 }
 
@@ -533,6 +581,229 @@ TEST_F(SqlTest, MultipleDecimalPointsTest) {
     auto result = normalizer_->normalize("SELECT * FROM t WHERE v = 1.2.3");
     // Document current behavior: treated as a single numeric token
     EXPECT_TRUE(result.parameters.find("1.2.3") != std::string::npos);
+}
+
+// ========== Ported Java DefaultSqlNormalizer Tests ==========
+
+TEST_F(SqlTest, JavaDefaultComplexCases) {
+    ExpectJavaCombine("select * from table a = 1 and b=50 and c=? and d='11'",
+        "select * from table a = 0# and b=1# and c=? and d='2$'", "1,50,11");
+    ExpectJavaCombine("select * from table a = -1 and b=-50 and c=? and d='-11'",
+        "select * from table a = -0# and b=-1# and c=? and d='2$'", "1,50,-11");
+    ExpectJavaCombine("select * from table a = +1 and b=+50 and c=? and d='+11'",
+        "select * from table a = +0# and b=+1# and c=? and d='2$'", "1,50,+11");
+    ExpectJavaCombine("select * from table a = 1/*test*/ and b=50/*test*/ and c=? and d='11'",
+        "select * from table a = 0#/*test*/ and b=1#/*test*/ and c=? and d='2$'", "1,50,11");
+    ExpectJavaCombine("select ZIPCODE,CITY from ZIPCODE", "select ZIPCODE,CITY from ZIPCODE", "");
+    ExpectJavaCombine("select a.ZIPCODE,a.CITY from ZIPCODE as a", "select a.ZIPCODE,a.CITY from ZIPCODE as a", "");
+    ExpectJavaCombine("select ZIPCODE,123 from ZIPCODE", "select ZIPCODE,0# from ZIPCODE", "123");
+    ExpectJavaCombine("SELECT * from table a=123 and b='abc' and c=1-3",
+        "SELECT * from table a=0# and b='1$' and c=2#-3#", "123,abc,1,3");
+    ExpectJavaCombine("SYSTEM_RANGE(1, 10)", "SYSTEM_RANGE(0#, 1#)", "1,10");
+}
+
+TEST_F(SqlTest, JavaDefaultObjectAndIdentifierCases) {
+    ExpectJavaDefaultNormalize("test.abc", "test.abc", "");
+    ExpectJavaDefaultNormalize("test.abc123", "test.abc123", "");
+    ExpectJavaDefaultNormalize("test.123", "test.123", "");
+}
+
+TEST_F(SqlTest, JavaDefaultNumberStateCases) {
+    ExpectJavaCombine("123", "0#", "123");
+    ExpectJavaCombine("-123", "-0#", "123");
+    ExpectJavaCombine("+123", "+0#", "123");
+    ExpectJavaCombine("1.23", "0#", "1.23");
+    ExpectJavaCombine("1.23.34", "0#", "1.23.34");
+    ExpectJavaCombine("123 456", "0# 1#", "123,456");
+    ExpectJavaCombine("1.23 4.56", "0# 1#", "1.23,4.56");
+    ExpectJavaCombine("1.23-4.56", "0#-1#", "1.23,4.56");
+
+    ExpectJavaCombine("1<2", "0#<1#", "1,2");
+    ExpectJavaCombine("1< 2", "0#< 1#", "1,2");
+    ExpectJavaCombine("(1< 2)", "(0#< 1#)", "1,2");
+
+    ExpectJavaDefaultNormalize("-- 1.23", "-- 1.23", "");
+    ExpectJavaCombine("- -1.23", "- -0#", "1.23");
+    ExpectJavaDefaultNormalize("--1.23", "--1.23", "");
+    ExpectJavaDefaultNormalize("/* 1.23 */", "/* 1.23 */", "");
+    ExpectJavaDefaultNormalize("/*1.23*/", "/*1.23*/", "");
+    ExpectJavaDefaultNormalize("/* 1.23 \n*/", "/* 1.23 \n*/", "");
+
+    ExpectJavaDefaultNormalize("test123", "test123", "");
+    ExpectJavaDefaultNormalize("test_123", "test_123", "");
+    ExpectJavaCombine("test_ 123", "test_ 0#", "123");
+    ExpectJavaCombine("123tst", "0#tst", "123");
+}
+
+TEST_F(SqlTest, JavaDefaultExponentNumberCases) {
+    ExpectJavaCombine("1.23e", "0#", "1.23e");
+    ExpectJavaCombine("1.23E", "0#", "1.23E");
+    ExpectJavaCombine("1.4e-10", "0#-1#", "1.4e,10");
+    ExpectJavaCombine("123 ", "0# ", "123");
+}
+
+TEST_F(SqlTest, JavaDefaultSingleLineCommentCases) {
+    ExpectJavaDefaultNormalize("--", "--", "");
+    ExpectJavaDefaultNormalize("//", "//", "");
+    ExpectJavaDefaultNormalize("--123", "--123", "");
+    ExpectJavaDefaultNormalize("//123", "//123", "");
+    ExpectJavaDefaultNormalize("--test", "--test", "");
+    ExpectJavaDefaultNormalize("//test", "//test", "");
+    ExpectJavaDefaultNormalize("--test\ntest", "--test\ntest", "");
+    ExpectJavaDefaultNormalize("--test\t\n", "--test\t\n", "");
+    ExpectJavaCombine("--test\n123 test", "--test\n0# test", "123");
+}
+
+TEST_F(SqlTest, JavaDefaultMultiLineCommentCases) {
+    ExpectJavaDefaultNormalize("/**/", "/**/", "");
+    ExpectJavaDefaultNormalize("/* */", "/* */", "");
+    ExpectJavaDefaultNormalize("/* */abc", "/* */abc", "");
+    ExpectJavaDefaultNormalize("/* * */", "/* * */", "");
+    ExpectJavaDefaultNormalize("/* abc", "/* abc", "");
+    ExpectJavaDefaultNormalize("select * from table", "select * from table", "");
+
+    ExpectJavaDefaultNormalize("/*", "/*", "");
+    ExpectJavaDefaultNormalize("/*  ", "/*  ", "");
+    ExpectJavaDefaultNormalize("/*  \n  ", "/*  \n  ", "");
+}
+
+TEST_F(SqlTest, JavaDefaultSymbolStateCases) {
+    ExpectJavaDefaultNormalize("''", "''", "");
+    ExpectJavaCombine("'abc'", "'0$'", "abc");
+    ExpectJavaCombine("'a''bc'", "'0$'", "a''bc");
+    ExpectJavaCombine("'a' 'bc'", "'0$' '1$'", "a,bc");
+    ExpectJavaCombine("'a''bc' 'a''bc'", "'0$' '1$'", "a''bc,a''bc");
+    ExpectJavaCombine("select * from table where a='a'", "select * from table where a='0$'", "a");
+}
+
+TEST_F(SqlTest, JavaDefaultCommentAndSymbolCases) {
+    ExpectJavaDefaultNormalize("/* 'test' */", "/* 'test' */", "");
+    ExpectJavaDefaultNormalize("/* 'test'' */", "/* 'test'' */", "");
+    ExpectJavaDefaultNormalize("/* '' */", "/* '' */", "");
+    ExpectJavaCombine("/*  */ 123 */", "/*  */ 0# */", "123");
+    ExpectJavaCombine("' /* */'", "'0$'", " /* */");
+}
+
+TEST_F(SqlTest, JavaDefaultSeparatorCases) {
+    ExpectJavaCombine("1234 456,7", "0# 1#,2#", "1234,456,7");
+    ExpectJavaCombine("'1234 456,7'", "'0$'", "1234 456,,7");
+    ExpectJavaCombine("'1234''456,7'", "'0$'", "1234''456,,7");
+    ExpectJavaCombine("'1234' '456,7'", "'0$' '1$'", "1234,456,,7");
+}
+
+TEST_F(SqlTest, JavaDefaultEmptyStringCases) {
+    ExpectJavaCombine(
+        "select u.user_no as userNo,ifnull(s.equipment,'') as equipment,ifnull(s.gender, '0') as gender from user u left join supply s on u.user_no = s.user_no where u.user_no = ?",
+        "select u.user_no as userNo,ifnull(s.equipment,'') as equipment,ifnull(s.gender, '0$') as gender from user u left join supply s on u.user_no = s.user_no where u.user_no = ?",
+        "0");
+    ExpectJavaCombine(
+        "select u.user_no as userNo,ifnull(s.equipment,'test_str') as equipment,ifnull(s.gender, '0') as gender from user u left join supply s on u.user_no = s.user_no where u.user_no != ''",
+        "select u.user_no as userNo,ifnull(s.equipment,'0$') as equipment,ifnull(s.gender, '1$') as gender from user u left join supply s on u.user_no = s.user_no where u.user_no != ''",
+        "test_str,0");
+    ExpectJavaCombine(
+        "select concat ('hello,', u.name, ?)as hello, u.user_no as userNo from user u where 1 = 1 and u.user_no = '10010'",
+        "select concat ('0$', u.name, ?)as hello, u.user_no as userNo from user u where 1# = 2# and u.user_no = '3$'",
+        "hello,,,1,1,10010");
+    ExpectJavaDefaultNormalize(
+        "select concat ('hello,', u.name, ' ')as hello, u.user_no as userNo from user u where 1 = 1 and u.user_no != ''",
+        "select concat ('0$', u.name, '1$')as hello, u.user_no as userNo from user u where 2# = 3# and u.user_no != ''",
+        "hello,,, ,1,1");
+    ExpectJavaCombine(
+        "select concat ('hello,', u.name, 'zhangsan')as hello, u.user_no as userNo from user u where 1 = 1 and u.user_no != '' and u.age > 20",
+        "select concat ('0$', u.name, '1$')as hello, u.user_no as userNo from user u where 2# = 3# and u.user_no != '' and u.age > 4#",
+        "hello,,,zhangsan,1,1,20");
+    ExpectJavaCombine(
+        "select concat ('pinpoint,', u.name, (select s.user_no from user s where s.user_no = '8888'))as hello, u.user_no as userNo from user u where 1 = 1 and u.habit != '2768' and u.age > 20",
+        "select concat ('0$', u.name, (select s.user_no from user s where s.user_no = '1$'))as hello, u.user_no as userNo from user u where 2# = 3# and u.habit != '4$' and u.age > 5#",
+        "pinpoint,,,8888,1,1,2768,20");
+    ExpectJavaCombine(
+        "SELECT n.order_logistics_id, MAX(IF(IFNULL(n.id, '') != '', '2', '0')) AS is_ts FROM t_e_shipping_note n WHERE IFNULL(n.delflag, '') <> '1' AND IFNULL(n.document_require, '0') = '2' GROUP BY n.order_logistics_id",
+        "SELECT n.order_logistics_id, MAX(IF(IFNULL(n.id, '') != '', '0$', '1$')) AS is_ts FROM t_e_shipping_note n WHERE IFNULL(n.delflag, '') <> '2$' AND IFNULL(n.document_require, '3$') = '4$' GROUP BY n.order_logistics_id",
+        "2,0,1,0,2");
+}
+
+TEST_F(SqlTest, JavaCombineOutputParamsCases) {
+    SqlNormalizer java_default(2048, false);
+    EXPECT_EQ(java_default.combineOutputParams("0# 1#", ParseOutputParameter("123,345")), "123 345");
+    EXPECT_EQ(java_default.combineOutputParams("0# 1# '2$'", ParseOutputParameter("123,345,test")), "123 345 'test'");
+    EXPECT_EQ(java_default.combineOutputParams("0# 1# 2# 3# 4# 5# 6# 7# 8# 9# 10#",
+        ParseOutputParameter("1,2,3,4,5,6,7,8,9,10,11")), "1 2 3 4 5 6 7 8 9 10 11");
+}
+
+TEST_F(SqlTest, JavaCombineOutputParamsErrorCases) {
+    SqlNormalizer java_default(2048, false);
+    EXPECT_EQ(java_default.combineOutputParams("0# 10#", ParseOutputParameter("123,345")), "123 10#");
+    EXPECT_EQ(java_default.combineOutputParams("0# 2# 10#", ParseOutputParameter("1,2,3")), "1 3 10#");
+    EXPECT_EQ(java_default.combineOutputParams("0# 2 3", ParseOutputParameter("1,2,3")), "1 2 3");
+    EXPECT_EQ(java_default.combineOutputParams("0# 2 10", ParseOutputParameter("1,2,3")), "1 2 10");
+    EXPECT_EQ(java_default.combineOutputParams("0# 2 201", ParseOutputParameter("1,2,3")), "1 2 201");
+    EXPECT_EQ(java_default.combineOutputParams("0# 2 10#", ParseOutputParameter("1,2,3,4,5,6,7,8,9,10,11")), "1 2 11");
+}
+
+TEST_F(SqlTest, JavaCombineBindValuesCases) {
+    SqlNormalizer java_default(2048, false);
+    EXPECT_EQ(java_default.combineBindValues(
+        "select * from table a = 1 and b=50 and c=? and d='11'",
+        ParseOutputParameter("foo")),
+        "select * from table a = 1 and b=50 and c='foo' and d='11'");
+    EXPECT_EQ(java_default.combineBindValues(
+        "select * from table a = ? and b=? and c=? and d=?",
+        ParseOutputParameter("1,50,  foo ,11")),
+        "select * from table a = '1' and b='50' and c=' foo ' and d='11'");
+    EXPECT_EQ(java_default.combineBindValues(
+        "select * from table a = ? and b=? and c=? and d=?",
+        ParseOutputParameter("1, 50, foo, 11")),
+        "select * from table a = '1' and b='50' and c='foo' and d='11'");
+    EXPECT_EQ(java_default.combineBindValues(
+        "select * from table id = \"foo ? bar\" and number=?",
+        ParseOutputParameter("99")),
+        "select * from table id = \"foo ? bar\" and number='99'");
+    EXPECT_EQ(java_default.combineBindValues(
+        "select * from table id = 'hi ? name''s foo' and number=?",
+        ParseOutputParameter("99")),
+        "select * from table id = 'hi ? name's foo' and number='99'");
+    EXPECT_EQ(java_default.combineBindValues(
+        "/** comment ? */ select * from table id = ?",
+        ParseOutputParameter("foo,,bar")),
+        "/** comment ? */ select * from table id = 'foo,bar'");
+    EXPECT_EQ(java_default.combineBindValues(
+        "select /*! STRAIGHT_JOIN ? */ * from table id = ?",
+        ParseOutputParameter("foo,,bar")),
+        "select /*! STRAIGHT_JOIN ? */ * from table id = 'foo,bar'");
+    EXPECT_EQ(java_default.combineBindValues(
+        "select * from table id = ?; -- This ? comment",
+        ParseOutputParameter("foo")),
+        "select * from table id = 'foo'; -- This ? comment");
+}
+
+TEST_F(SqlTest, JavaRemoveCommentsCases) {
+    SqlNormalizer remove_comments(2048, true);
+    ExpectNormalize(remove_comments, "/** comment ? */ select * from table id = 'foo'",
+        " select * from table id = '0$'", "foo");
+    ExpectNormalize(remove_comments, "//comment\nselect * from table id = ?;",
+        "select * from table id = ?;", "");
+    ExpectNormalize(remove_comments, "--comment\nselect * from table id = ?;",
+        "select * from table id = ?;", "");
+    ExpectNormalize(remove_comments, "select */*comment*/ \nfrom table id = ?;",
+        "select * \nfrom table id = ?;", "");
+    ExpectNormalize(remove_comments, "select * from table id = ?; /* This ? comment*/",
+        "select * from table id = ?; ", "");
+    ExpectNormalize(remove_comments, "select * from table id = ?; // This ? comment",
+        "select * from table id = ?; ", "");
+    ExpectNormalize(remove_comments, "select * from table id = ?; -- This ? comment",
+        "select * from table id = ?; ", "");
+}
+
+TEST_F(SqlTest, JavaPostgresPositionalParameterCases) {
+    ExpectJavaCombine("SELECT * FROM member WHERE user = 'Kim' AND id = $1 AND no = 10",
+        "SELECT * FROM member WHERE user = '0$' AND id = $1 AND no = 1#", "Kim,10");
+    ExpectJavaCombine("SELECT * FROM member WHERE id = $122309 AND no = 122309",
+        "SELECT * FROM member WHERE id = $122309 AND no = 0#", "122309");
+    ExpectJavaCombine("$value, 123", "$value, 0#", "123");
+    ExpectJavaCombine("'$123', 123", "'0$', 1#", "$123,123");
+    ExpectJavaCombine("$; 123", "$; 0#", "123");
+    ExpectJavaCombine("$(123); 123", "$(0#); 1#", "123,123");
+    ExpectJavaCombine("'$''123'", "'0$'", "$''123");
 }
 
 } // namespace pinpoint


### PR DESCRIPTION
## Summary
- Align C++ SqlNormalizer token handling with Java DefaultSqlNormalizer / ParserContext behavior
- Add comment-removal mode while preserving the existing C++ agent default of removing comments
- Port Java DefaultSqlNormalizerTest coverage for normalization, output-param combine, bind-value combine, comment removal, and PostgreSQL positional parameters

## Validation
- cmake --build build/fetchcontent --target test_sql
- build/fetchcontent/test/test_sql
- cmake --build build/fetchcontent --target test_span_event
- build/fetchcontent/test/test_span_event

Closes #75