### PR TITLE
[#77] Refactor gRPC metadata sender

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -37,10 +37,12 @@ namespace pinpoint {
 
     AgentImpl::AgentImpl(std::shared_ptr<const Config> cfg,
                          std::unique_ptr<GrpcAgent> grpc_agent,
+                         std::unique_ptr<GrpcMetadata> grpc_metadata,
                          std::unique_ptr<GrpcSpan> grpc_span,
                          std::unique_ptr<GrpcStats> grpc_stat) :
         config_(std::shared_ptr<const Config>(std::move(cfg))),
         grpc_agent_(std::move(grpc_agent)),
+        grpc_metadata_(std::move(grpc_metadata)),
         grpc_span_(std::move(grpc_span)),
         grpc_stat_(std::move(grpc_stat)),
         start_time_(to_milli_seconds(std::chrono::system_clock::now())),
@@ -174,6 +176,7 @@ namespace pinpoint {
 
     void AgentImpl::init_grpc_workers() try {
         grpc_agent_->setAgentService(this);
+        grpc_metadata_->setAgentService(this);
         grpc_span_->setAgentService(this);
         grpc_stat_->setAgentService(this);
 
@@ -184,7 +187,7 @@ namespace pinpoint {
         } while (grpc_agent_->registerAgent() != SEND_OK);
 
         ping_thread_ = std::thread{&GrpcAgent::sendPingWorker, grpc_agent_.get()};
-        meta_thread_ = std::thread{&GrpcAgent::sendMetaWorker, grpc_agent_.get()};
+        meta_thread_ = std::thread{&GrpcMetadata::sendMetaWorker, grpc_metadata_.get()};
         span_thread_ = std::thread{&GrpcSpan::sendSpanWorker, grpc_span_.get()};
         stat_thread_ = std::thread{&GrpcStats::sendStatsWorker, grpc_stat_.get()};
         url_stat_add_thread_ = std::thread{&UrlStats::addUrlStatsWorker, url_stats_.get()};
@@ -203,13 +206,14 @@ namespace pinpoint {
         url_stats_->stopSendUrlStatsWorker();
         agent_stats_->stopAgentStatsWorker();
         grpc_agent_->stopPingWorker();
-        grpc_agent_->stopMetaWorker();
+        grpc_metadata_->stopMetaWorker();
         grpc_span_->stopSpanWorker();
         grpc_stat_->stopStatsWorker();
 
         wait_grpc_workers();
 
         grpc_agent_->closeChannel();
+        grpc_metadata_->closeChannel();
         grpc_stat_->closeChannel();
         grpc_span_->closeChannel();
 
@@ -407,7 +411,7 @@ namespace pinpoint {
         }
 
         auto meta = std::make_unique<MetaData>(META_API, id, api_type, api_str);
-        grpc_agent_->enqueueMeta(std::move(meta));
+        grpc_metadata_->enqueueMeta(std::move(meta));
 
         return id;
     } catch (const std::exception &e) {
@@ -435,7 +439,7 @@ namespace pinpoint {
         }
 
         auto meta = std::make_unique<MetaData>(META_STRING, id, error_name, STRING_META_ERROR);
-        grpc_agent_->enqueueMeta(std::move(meta));
+        grpc_metadata_->enqueueMeta(std::move(meta));
 
         return id;
     } catch (const std::exception &e) {
@@ -460,7 +464,7 @@ namespace pinpoint {
         }
 
         auto meta = std::make_unique<MetaData>(META_STRING, id, sql_query, STRING_META_SQL);
-        grpc_agent_->enqueueMeta(std::move(meta));
+        grpc_metadata_->enqueueMeta(std::move(meta));
 
         return id;
     } catch (const std::exception &e) {
@@ -485,7 +489,7 @@ namespace pinpoint {
         }
         
         auto meta = std::make_unique<MetaData>(META_SQL_UID, uid, sql);
-        grpc_agent_->enqueueMeta(std::move(meta));
+        grpc_metadata_->enqueueMeta(std::move(meta));
         
         return uid;
     } catch (const std::exception &e) {
@@ -508,7 +512,7 @@ namespace pinpoint {
         auto meta = std::make_unique<MetaData>(META_EXCEPTION, span_data->getTraceId(), 
                                                span_data->getSpanId(), span_data->getUrlTemplate(),
                                                span_data->takeExceptions());
-        grpc_agent_->enqueueMeta(std::move(meta));
+        grpc_metadata_->enqueueMeta(std::move(meta));
     }
 
     bool AgentImpl::isStatusFail(const int status) const {
@@ -545,10 +549,11 @@ namespace pinpoint {
         }
         try {
             auto grpc_agent = std::make_unique<GrpcAgent>(cfg);
+            auto grpc_metadata = std::make_unique<GrpcMetadata>(cfg);
             auto grpc_span = std::make_unique<GrpcSpan>(cfg);
             auto grpc_stat = std::make_unique<GrpcStats>(cfg);
             return std::make_shared<AgentImpl>(cfg,
-                std::move(grpc_agent), std::move(grpc_span), std::move(grpc_stat));
+                std::move(grpc_agent), std::move(grpc_metadata), std::move(grpc_span), std::move(grpc_stat));
         } catch (const std::exception& e) {
             LOG_ERROR("make agent exception = {}", e.what());
             return nullptr;

--- a/src/agent.h
+++ b/src/agent.h
@@ -49,6 +49,7 @@ namespace pinpoint {
 		 */
 		AgentImpl(std::shared_ptr<const Config> options,
 				  std::unique_ptr<GrpcAgent> grpc_agent,
+				  std::unique_ptr<GrpcMetadata> grpc_metadata,
 				  std::unique_ptr<GrpcSpan> grpc_span,
 				  std::unique_ptr<GrpcStats> grpc_stat);
         ~AgentImpl() noexcept override;
@@ -125,6 +126,7 @@ namespace pinpoint {
     	std::unique_ptr<SqlUidCache> sql_uid_cache_{};
 
     	std::unique_ptr<GrpcAgent> grpc_agent_{};
+    	std::unique_ptr<GrpcMetadata> grpc_metadata_{};
     	std::unique_ptr<GrpcSpan> grpc_span_{};
     	std::unique_ptr<GrpcStats> grpc_stat_{};
     	std::unique_ptr<UrlStats> url_stats_{};
@@ -169,4 +171,3 @@ namespace pinpoint {
     void reset_global_agent();
 
 }  // namespace pinpoint
-

--- a/src/grpc.cpp
+++ b/src/grpc.cpp
@@ -374,6 +374,9 @@ namespace pinpoint {
         if (client_type == AGENT) {
             addr = absl::StrCat(addr, config_->collector.agent_port);
             client_name_ = "agent";
+        } else if (client_type == METADATA) {
+            addr = absl::StrCat(addr, config_->collector.agent_port);
+            client_name_ = "metadata";
         } else if (client_type == SPAN) {
             addr = absl::StrCat(addr, config_->collector.span_port);
             client_name_ = "span";
@@ -462,19 +465,278 @@ namespace pinpoint {
         return true;
     }
 
-    //GrpcAgent
-
-    GrpcAgent::GrpcAgent(std::shared_ptr<const Config> config) : GrpcClient(AGENT, std::move(config)) {
-        set_agent_stub(v1::Agent::NewStub(channel_));
-        set_meta_stub(v1::Metadata::NewStub(channel_));
-    }
-
     constexpr auto REGISTER_TIMEOUT = std::chrono::seconds(60);
     constexpr auto META_TIMEOUT = std::chrono::seconds(5);
+    constexpr int METADATA_RETRY_MAX_ATTEMPTS = 3;
+    constexpr auto METADATA_RETRY_DELAY = std::chrono::milliseconds(1000);
 
     static void set_deadline(grpc::ClientContext& ctx, const std::chrono::seconds timeout) {
         auto deadline = std::chrono::system_clock::now() + timeout;
         ctx.set_deadline(deadline);
+    }
+
+    //GrpcMetadata
+
+    GrpcMetadata::GrpcMetadata(std::shared_ptr<const Config> config) : GrpcClient(METADATA, std::move(config)) {
+        set_meta_stub(v1::Metadata::NewStub(channel_));
+    }
+
+    template<typename Request, typename StubMethod>
+    GrpcRequestStatus GrpcMetadata::send_meta_helper(StubMethod stub_method, Request& request, std::string_view operation_name) {
+        v1::PResult reply;
+        grpc::ClientContext ctx;
+        std::unique_lock<std::mutex> lock(channel_mutex_);
+
+        build_grpc_context(&ctx, 0);
+        set_deadline(ctx, META_TIMEOUT);
+        
+        const grpc::Status status = stub_method(&ctx, request, &reply);
+
+        if (!status.ok()) {
+            LOG_ERROR("failed to send {} metadata: {}, {}",
+                      operation_name, static_cast<int>(status.error_code()), status.error_message());
+            return SEND_FAIL;
+        }
+
+        if (!reply.success()) {
+            LOG_INFO("failed to send {} metadata: PResult.success=false", operation_name);
+            return SEND_FAIL;
+        }
+
+        LOG_DEBUG("success to send {} metadata", operation_name);
+        return SEND_OK;
+    }
+
+    GrpcRequestStatus GrpcMetadata::send_api_meta(ApiMeta& api_meta) {
+        v1::PApiMetaData grpc_api_meta;
+
+        grpc_api_meta.set_apiid(api_meta.id_);
+        grpc_api_meta.set_apiinfo(api_meta.api_str_);
+        grpc_api_meta.set_type(api_meta.type_);
+
+        auto stub_method = [this](grpc::ClientContext* ctx, const v1::PApiMetaData& req, v1::PResult* reply) {
+            return meta_stub_->RequestApiMetaData(ctx, req, reply);
+        };
+
+        return send_meta_helper(stub_method, grpc_api_meta, "api");
+    }
+
+    GrpcRequestStatus GrpcMetadata::send_error_meta(StringMeta& error_meta) {
+        v1::PStringMetaData grpc_error_meta;
+
+        grpc_error_meta.set_stringid(error_meta.id_);
+        grpc_error_meta.set_stringvalue(error_meta.str_val_);
+
+        auto stub_method = [this](grpc::ClientContext* ctx, const v1::PStringMetaData& req, v1::PResult* reply) {
+            return meta_stub_->RequestStringMetaData(ctx, req, reply);
+        };
+
+        return send_meta_helper(stub_method, grpc_error_meta, "error");
+    }
+
+    GrpcRequestStatus GrpcMetadata::send_sql_meta(StringMeta& sql_meta) {
+        v1::PSqlMetaData grpc_sql_meta;
+
+        grpc_sql_meta.set_sqlid(sql_meta.id_);
+        grpc_sql_meta.set_sql(sql_meta.str_val_);
+
+        auto stub_method = [this](grpc::ClientContext* ctx, const v1::PSqlMetaData& req, v1::PResult* reply) {
+            return meta_stub_->RequestSqlMetaData(ctx, req, reply);
+        };
+
+        return send_meta_helper(stub_method, grpc_sql_meta, "sql");
+    }
+
+    GrpcRequestStatus GrpcMetadata::send_sql_uid_meta(SqlUidMeta& sql_uid_meta) {
+        v1::PSqlUidMetaData grpc_sql_uid_meta;
+
+        // convert vector<unsigned char> to string (copy)
+        std::string_view uid_view(
+            reinterpret_cast<const char*>(sql_uid_meta.uid_.data()),
+            sql_uid_meta.uid_.size()
+        );
+        grpc_sql_uid_meta.set_sqluid(std::string(uid_view));
+        grpc_sql_uid_meta.set_sql(sql_uid_meta.sql_);
+
+        auto stub_method = [this](grpc::ClientContext* ctx, const v1::PSqlUidMetaData& req, v1::PResult* reply) {
+            return meta_stub_->RequestSqlUidMetaData(ctx, req, reply);
+        };
+
+        return send_meta_helper(stub_method, grpc_sql_uid_meta, "sql uid");
+    }
+
+    GrpcRequestStatus GrpcMetadata::send_exception_meta(ExceptionMeta& exception_meta) {
+        google::protobuf::Arena arena;
+        auto* grpc_exception_meta = google::protobuf::Arena::Create<v1::PExceptionMetaData>(&arena);
+
+        grpc_exception_meta->unsafe_arena_set_allocated_transactionid(build_transaction_id(exception_meta.txid_, &arena));
+        grpc_exception_meta->set_spanid(exception_meta.span_id_);
+        grpc_exception_meta->set_uritemplate(exception_meta.url_template_);
+
+        for (const auto& exception : exception_meta.exceptions_) {
+            auto* grpc_exception = grpc_exception_meta->add_exceptions();
+            const auto& callstack = exception->getCallStack();
+
+            grpc_exception->set_exceptionid(exception->getId());
+            grpc_exception->set_exceptionclassname(callstack.getModuleName());
+            grpc_exception->set_exceptionmessage(callstack.getErrorMessage());
+            grpc_exception->set_starttime(callstack.getErrorTime());
+            grpc_exception->set_exceptiondepth(1);
+
+            for (const auto& frame : callstack.getStack()) {
+                auto* grpc_callstack = grpc_exception->add_stacktraceelement();
+
+                grpc_callstack->set_classname(frame.module);
+                grpc_callstack->set_filename(frame.file);
+                grpc_callstack->set_linenumber(frame.line);
+                grpc_callstack->set_methodname(frame.function);
+            }
+        }
+
+        auto stub_method = [this](grpc::ClientContext* ctx, const v1::PExceptionMetaData& req, v1::PResult* reply) {
+            return meta_stub_->RequestExceptionMetaData(ctx, req, reply);
+        };
+
+        return send_meta_helper(stub_method, *grpc_exception_meta, "exception");
+    }
+
+    GrpcRequestStatus GrpcMetadata::send_meta(MetaData& meta) {
+        return std::visit([this](auto&& value) {
+            using T = std::decay_t<decltype(value)>;
+            if constexpr (std::is_same_v<T, ApiMeta>) {
+                return send_api_meta(value);
+            } else if constexpr (std::is_same_v<T, StringMeta>) {
+                if (value.type_ == STRING_META_ERROR) {
+                    return send_error_meta(value);
+                }
+                return send_sql_meta(value);
+            } else if constexpr (std::is_same_v<T, SqlUidMeta>) {
+                return send_sql_uid_meta(value);
+            } else if constexpr (std::is_same_v<T, ExceptionMeta>) {
+                return send_exception_meta(value);
+            }
+            return SEND_FAIL;
+        }, meta.value_);
+    }
+
+    void GrpcMetadata::release_failed_cache(const MetaData& meta) const {
+        std::visit([this](const auto& value) {
+            using T = std::decay_t<decltype(value)>;
+            if constexpr (std::is_same_v<T, ApiMeta>) {
+                agent_->removeCacheApi(value);
+            } else if constexpr (std::is_same_v<T, StringMeta>) {
+                if (value.type_ == STRING_META_ERROR) {
+                    agent_->removeCacheError(value);
+                } else if (value.type_ == STRING_META_SQL) {
+                    agent_->removeCacheSql(value);
+                }
+            } else if constexpr (std::is_same_v<T, SqlUidMeta>) {
+                agent_->removeCacheSqlUid(value);
+            }
+        }, meta.value_);
+    }
+
+    void GrpcMetadata::enqueueMeta(std::unique_ptr<MetaData> meta) noexcept try {
+        if (meta == nullptr || (agent_ != nullptr && agent_->isExiting())) {
+            return;
+        }
+
+        std::unique_lock<std::mutex> lock(meta_queue_mutex_);
+
+        const auto& config = config_;
+        if (meta_queue_.size() + retry_queue_.size() < config->span.queue_size) {
+            meta_queue_.push_back(PendingMeta{std::move(meta), 0, {}, meta_sequence_++});
+        } else {
+            LOG_DEBUG("drop metadata: overflow max queue size {}", config->span.queue_size);
+        }
+
+        meta_queue_cv_.notify_one();
+    } catch (const std::exception &e) {
+        LOG_ERROR("failed to enqueue metadata: exception = {}", e.what());
+    }
+
+    void GrpcMetadata::schedule_retry(PendingMeta&& pending) {
+        pending.available_at = std::chrono::steady_clock::now() + METADATA_RETRY_DELAY;
+        pending.sequence = meta_sequence_++;
+        retry_queue_.emplace(pending.available_at, std::move(pending));
+        meta_queue_cv_.notify_one();
+    }
+
+    bool GrpcMetadata::pop_next_meta(PendingMeta& pending, std::unique_lock<std::mutex>& lock) {
+        while (true) {
+            if (agent_->isExiting()) {
+                return false;
+            }
+
+            if (!meta_queue_.empty()) {
+                pending = std::move(meta_queue_.front());
+                meta_queue_.pop_front();
+                return true;
+            }
+
+            const auto now = std::chrono::steady_clock::now();
+            if (!retry_queue_.empty()) {
+                auto retry = retry_queue_.begin();
+                if (retry->first <= now) {
+                    pending = std::move(retry->second);
+                    retry_queue_.erase(retry);
+                    return true;
+                }
+
+                meta_queue_cv_.wait_until(lock, retry->first, [this] {
+                    return !meta_queue_.empty() || agent_->isExiting();
+                });
+            } else {
+                meta_queue_cv_.wait(lock, [this] {
+                    return !meta_queue_.empty() || !retry_queue_.empty() || agent_->isExiting();
+                });
+            }
+        }
+    }
+
+    void GrpcMetadata::sendMetaWorker() try {
+        while (true) {
+            PendingMeta pending;
+            {
+                std::unique_lock<std::mutex> lock(meta_queue_mutex_);
+                if (!pop_next_meta(pending, lock)) {
+                    break;
+                }
+            }
+
+            const auto sent = send_meta(*pending.meta) == SEND_OK;
+            if (sent) {
+                continue;
+            }
+
+            ++pending.retry_count;
+            if (agent_->isExiting()) {
+                break;
+            }
+
+            std::unique_lock<std::mutex> lock(meta_queue_mutex_);
+            if (pending.retry_count <= METADATA_RETRY_MAX_ATTEMPTS) {
+                LOG_DEBUG("retry metadata send: retryCount={}/{}", pending.retry_count, METADATA_RETRY_MAX_ATTEMPTS);
+                schedule_retry(std::move(pending));
+            } else {
+                LOG_INFO("drop metadata after retry exhaustion: retryCount={}", pending.retry_count);
+                release_failed_cache(*pending.meta);
+            }
+        }
+        LOG_INFO("send meta worker end");
+    } catch (const std::exception& e) {
+        LOG_ERROR("failed to send grpc meta: exception = {}", e.what());
+    }
+
+    void GrpcMetadata::stopMetaWorker() {
+        std::unique_lock<std::mutex> lock(meta_queue_mutex_);
+        meta_queue_cv_.notify_all();
+    }
+
+    //GrpcAgent
+
+    GrpcAgent::GrpcAgent(std::shared_ptr<const Config> config) : GrpcClient(AGENT, std::move(config)) {
+        set_agent_stub(v1::Agent::NewStub(channel_));
     }
 
     void GrpcAgent::build_agent_info(v1::PAgentInfo* agent_info, google::protobuf::Arena* arena) const {
@@ -513,188 +775,6 @@ namespace pinpoint {
 
         LOG_ERROR("failed to register the agent: {}, {}", static_cast<int>(status.error_code()), status.error_message());
         return SEND_FAIL;
-    }
-
-    template<typename Request, typename StubMethod>
-    GrpcRequestStatus GrpcAgent::send_meta_helper(StubMethod stub_method, Request& request, std::string_view operation_name) {
-        v1::PResult reply;
-        grpc::ClientContext ctx;
-        std::unique_lock<std::mutex> lock(channel_mutex_);
-
-        build_grpc_context(&ctx, 0);
-        set_deadline(ctx, META_TIMEOUT);
-        
-        const grpc::Status status = stub_method(&ctx, request, &reply);
-
-        if (status.ok()) {
-            LOG_DEBUG("success to send {} metadata", operation_name);
-            return SEND_OK;
-        }
-
-        LOG_ERROR("failed to send {} metadata: {}, {}", 
-                  operation_name, static_cast<int>(status.error_code()), status.error_message());
-        return SEND_FAIL;
-    }
-
-    GrpcRequestStatus GrpcAgent::send_api_meta(ApiMeta& api_meta) {
-        v1::PApiMetaData grpc_api_meta;
-
-        grpc_api_meta.set_apiid(api_meta.id_);
-        grpc_api_meta.set_apiinfo(api_meta.api_str_);
-        grpc_api_meta.set_type(api_meta.type_);
-
-        auto stub_method = [this](grpc::ClientContext* ctx, const v1::PApiMetaData& req, v1::PResult* reply) {
-            return meta_stub_->RequestApiMetaData(ctx, req, reply);
-        };
-
-        return send_meta_helper(stub_method, grpc_api_meta, "api");
-    }
-
-    GrpcRequestStatus GrpcAgent::send_error_meta(StringMeta& error_meta) {
-        v1::PStringMetaData grpc_error_meta;
-
-        grpc_error_meta.set_stringid(error_meta.id_);
-        grpc_error_meta.set_stringvalue(error_meta.str_val_);
-
-        auto stub_method = [this](grpc::ClientContext* ctx, const v1::PStringMetaData& req, v1::PResult* reply) {
-            return meta_stub_->RequestStringMetaData(ctx, req, reply);
-        };
-
-        return send_meta_helper(stub_method, grpc_error_meta, "error");
-    }
-
-    GrpcRequestStatus GrpcAgent::send_sql_meta(StringMeta& sql_meta) {
-        v1::PSqlMetaData grpc_sql_meta;
-
-        grpc_sql_meta.set_sqlid(sql_meta.id_);
-        grpc_sql_meta.set_sql(sql_meta.str_val_);
-
-        auto stub_method = [this](grpc::ClientContext* ctx, const v1::PSqlMetaData& req, v1::PResult* reply) {
-            return meta_stub_->RequestSqlMetaData(ctx, req, reply);
-        };
-
-        return send_meta_helper(stub_method, grpc_sql_meta, "sql");
-    }
-
-    GrpcRequestStatus GrpcAgent::send_sql_uid_meta(SqlUidMeta& sql_uid_meta) {
-        v1::PSqlUidMetaData grpc_sql_uid_meta;
-
-        // convert vector<unsigned char> to string (copy)
-        std::string_view uid_view(
-            reinterpret_cast<const char*>(sql_uid_meta.uid_.data()),
-            sql_uid_meta.uid_.size()
-        );
-        grpc_sql_uid_meta.set_sqluid(std::string(uid_view));
-        grpc_sql_uid_meta.set_sql(sql_uid_meta.sql_);
-
-        auto stub_method = [this](grpc::ClientContext* ctx, const v1::PSqlUidMetaData& req, v1::PResult* reply) {
-            return meta_stub_->RequestSqlUidMetaData(ctx, req, reply);
-        };
-
-        return send_meta_helper(stub_method, grpc_sql_uid_meta, "sql uid");
-    }
-
-    GrpcRequestStatus GrpcAgent::send_exception_meta(ExceptionMeta& exception_meta) {
-        google::protobuf::Arena arena;
-        auto* grpc_exception_meta = google::protobuf::Arena::Create<v1::PExceptionMetaData>(&arena);
-
-        grpc_exception_meta->unsafe_arena_set_allocated_transactionid(build_transaction_id(exception_meta.txid_, &arena));
-        grpc_exception_meta->set_spanid(exception_meta.span_id_);
-        grpc_exception_meta->set_uritemplate(exception_meta.url_template_);
-
-        for (const auto& exception : exception_meta.exceptions_) {
-            auto* grpc_exception = grpc_exception_meta->add_exceptions();
-            const auto& callstack = exception->getCallStack();
-
-            grpc_exception->set_exceptionid(exception->getId());
-            grpc_exception->set_exceptionclassname(callstack.getModuleName());
-            grpc_exception->set_exceptionmessage(callstack.getErrorMessage());
-            grpc_exception->set_starttime(callstack.getErrorTime());
-            grpc_exception->set_exceptiondepth(1);
-
-            for (const auto& frame : callstack.getStack()) {
-                auto* grpc_callstack = grpc_exception->add_stacktraceelement();
-
-                grpc_callstack->set_classname(frame.module);  
-                grpc_callstack->set_filename(frame.file);
-                grpc_callstack->set_linenumber(frame.line);
-                grpc_callstack->set_methodname(frame.function);
-            }
-        }
-
-        auto stub_method = [this](grpc::ClientContext* ctx, const v1::PExceptionMetaData& req, v1::PResult* reply) {
-            return meta_stub_->RequestExceptionMetaData(ctx, req, reply);
-        };
-
-        return send_meta_helper(stub_method, *grpc_exception_meta, "exception");
-    }
-
-    void GrpcAgent::enqueueMeta(std::unique_ptr<MetaData> meta) noexcept try {
-        std::unique_lock<std::mutex> lock(meta_queue_mutex_);
-
-        const auto& config = config_;
-        if (meta_queue_.size() < config->span.queue_size) {
-            meta_queue_.push(std::move(meta));
-        } else {
-            LOG_DEBUG("drop metadata: overflow max queue size {}", config->span.queue_size);
-        }
-
-        meta_queue_cv_.notify_one();
-    } catch (const std::exception &e) {
-        LOG_ERROR("failed to enqueue metadata: exception = {}", e.what());
-    }
-
-    void GrpcAgent::sendMetaWorker() try {
-        std::unique_lock<std::mutex> lock(meta_queue_mutex_);
-
-        while (true) {
-            meta_queue_cv_.wait(lock, [this]{
-                return !meta_queue_.empty() || agent_->isExiting();
-            });
-            if (agent_->isExiting()) {
-                break;
-            }
-
-            const auto meta = std::move(meta_queue_.front());
-            meta_queue_.pop();
-            lock.unlock();
-
-            // Use std::visit for type-safe variant handling
-            std::visit([this](auto&& value) {
-                using T = std::decay_t<decltype(value)>;
-                if constexpr (std::is_same_v<T, ApiMeta>) {
-                    if (send_api_meta(value) != SEND_OK) {
-                        agent_->removeCacheApi(value);
-                    }
-                } else if constexpr (std::is_same_v<T, StringMeta>) {
-                    if (value.type_ == STRING_META_ERROR) {
-                        if (send_error_meta(value) != SEND_OK) {
-                            agent_->removeCacheError(value);
-                        }
-                    } else if (value.type_ == STRING_META_SQL) {
-                        if (send_sql_meta(value) != SEND_OK) {
-                            agent_->removeCacheSql(value);
-                        }
-                    }
-                } else if constexpr (std::is_same_v<T, SqlUidMeta>) {
-                    if (send_sql_uid_meta(value) != SEND_OK) {
-                        agent_->removeCacheSqlUid(value);
-                    }
-                } else if constexpr (std::is_same_v<T, ExceptionMeta>) {
-                    send_exception_meta(value);
-                }
-            }, meta->value_);
-
-            lock.lock();
-        }
-        LOG_INFO("send meta worker end");
-    } catch (const std::exception& e) {
-        LOG_ERROR("failed to send grpc meta: exception = {}", e.what());
-    }
-
-    void GrpcAgent::stopMetaWorker() {
-        std::unique_lock<std::mutex> lock(meta_queue_mutex_);
-        meta_queue_cv_.notify_one();
     }
 
     // Ping Stream

--- a/src/grpc.h
+++ b/src/grpc.h
@@ -19,8 +19,10 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <deque>
 #include <queue>
 #include <string>
 #include <variant>
@@ -52,7 +54,7 @@ namespace pinpoint {
     /**
      * @brief Identifies the type of gRPC client sharing common facilities.
      */
-    enum ClientType {AGENT, SPAN, STATS};
+    enum ClientType {AGENT, METADATA, SPAN, STATS};
 
     /**
      * @brief Base client that encapsulates channel management shared by all gRPC workers.
@@ -198,7 +200,58 @@ namespace pinpoint {
     };
 
     /**
-     * @brief gRPC client responsible for agent registration, ping and metadata upload.
+     * @brief gRPC client responsible for metadata upload.
+     */
+    class GrpcMetadata : public GrpcClient {
+    public:
+        explicit GrpcMetadata(std::shared_ptr<const Config> config);
+        ~GrpcMetadata() override = default;
+
+        /**
+         * @brief Adds metadata to the outbound queue.
+         *
+         * @param meta Metadata payload (ownership transferred).
+         */
+        void enqueueMeta(std::unique_ptr<MetaData> meta) noexcept;
+        /// @brief Worker loop that sends metadata payloads.
+        void sendMetaWorker();
+        /// @brief Stops the metadata worker loop.
+        void stopMetaWorker();
+
+    protected:
+        void set_meta_stub(std::unique_ptr<v1::Metadata::StubInterface> stub) { meta_stub_ = std::move(stub); }
+
+    private:
+        struct PendingMeta {
+            std::unique_ptr<MetaData> meta;
+            int retry_count{0};
+            std::chrono::steady_clock::time_point available_at{};
+            uint64_t sequence{0};
+        };
+
+        std::unique_ptr<v1::Metadata::StubInterface> meta_stub_{};
+
+        std::deque<PendingMeta> meta_queue_{};
+        std::multimap<std::chrono::steady_clock::time_point, PendingMeta> retry_queue_{};
+        std::mutex meta_queue_mutex_{};
+        std::condition_variable meta_queue_cv_{};
+        uint64_t meta_sequence_{0};
+
+        template<typename Request, typename StubMethod>
+        GrpcRequestStatus send_meta_helper(StubMethod stub_method, Request& request, std::string_view operation_name);
+        GrpcRequestStatus send_api_meta(ApiMeta& api_meta);
+        GrpcRequestStatus send_error_meta(StringMeta& error_meta);
+        GrpcRequestStatus send_sql_meta(StringMeta& sql_meta);
+        GrpcRequestStatus send_sql_uid_meta(SqlUidMeta& sql_uid_meta);
+        GrpcRequestStatus send_exception_meta(ExceptionMeta& exception_meta);
+        GrpcRequestStatus send_meta(MetaData& meta);
+        void release_failed_cache(const MetaData& meta) const;
+        void schedule_retry(PendingMeta&& pending);
+        bool pop_next_meta(PendingMeta& pending, std::unique_lock<std::mutex>& lock);
+    };
+
+    /**
+     * @brief gRPC client responsible for agent registration and ping.
      */
     class GrpcAgent : public GrpcClient, public grpc::ClientBidiReactor<v1::PPing, v1::PPing> {
     public:
@@ -208,21 +261,11 @@ namespace pinpoint {
          * @brief Registers the agent with the collector and starts ping streaming.
          */
         virtual GrpcRequestStatus registerAgent();
-        /**
-         * @brief Adds metadata to the outbound queue.
-         *
-         * @param meta Metadata payload (ownership transferred).
-         */
-        void enqueueMeta(std::unique_ptr<MetaData> meta) noexcept;
 
         /// @brief Worker loop that periodically sends ping requests.
         void sendPingWorker();
         /// @brief Stops the ping worker loop.
         void stopPingWorker();
-        /// @brief Worker loop that streams metadata payloads.
-        void sendMetaWorker();
-        /// @brief Stops the metadata worker loop.
-        void stopMetaWorker();
 
         //grpc::ClientBidiReactor
         /// @brief Notification invoked after each write completes.
@@ -234,32 +277,19 @@ namespace pinpoint {
 
     protected:
         void set_agent_stub(std::unique_ptr<v1::Agent::StubInterface> stub) { agent_stub_ = std::move(stub); }
-        void set_meta_stub(std::unique_ptr<v1::Metadata::StubInterface> stub) { meta_stub_ = std::move(stub); }
 
     private:
         std::unique_ptr<v1::Agent::StubInterface> agent_stub_{};
-        std::unique_ptr<v1::Metadata::StubInterface> meta_stub_{};
 
         v1::PPing ping_{}, pong_{};
         std::mutex ping_worker_mutex_{};
         std::condition_variable ping_cv_{};
         unsigned long socket_id_{0};
 
-        std::queue<std::unique_ptr<MetaData>> meta_queue_{};
-        std::mutex meta_queue_mutex_{};
-        std::condition_variable meta_queue_cv_{};
-
         bool start_ping_stream();
         void finish_ping_stream();
         GrpcStreamStatus write_and_await_ping_stream();
 
-        template<typename Request, typename StubMethod>
-        GrpcRequestStatus send_meta_helper(StubMethod stub_method, Request& request, std::string_view operation_name);
-        GrpcRequestStatus send_api_meta(ApiMeta& api_meta);
-        GrpcRequestStatus send_error_meta(StringMeta& error_meta);
-        GrpcRequestStatus send_sql_meta(StringMeta& sql_meta);
-        GrpcRequestStatus send_sql_uid_meta(SqlUidMeta& sql_uid_meta);
-        GrpcRequestStatus send_exception_meta(ExceptionMeta& exception_meta);
         void build_agent_info(v1::PAgentInfo* agent_info, google::protobuf::Arena* arena) const;
     };
 

--- a/test/mock_agent_service.h
+++ b/test/mock_agent_service.h
@@ -87,7 +87,9 @@ public:
         return cached_apis_[key];
     }
 
-    void removeCacheApi(const ApiMeta& api_meta) const override {}
+    void removeCacheApi(const ApiMeta& api_meta) const override {
+        removed_api_count_++;
+    }
 
     int32_t cacheError(std::string_view error_name) const override {
         auto key = std::string(error_name);
@@ -97,7 +99,9 @@ public:
         return cached_errors_[key];
     }
 
-    void removeCacheError(const StringMeta& error_meta) const override {}
+    void removeCacheError(const StringMeta& error_meta) const override {
+        removed_error_count_++;
+    }
 
     int32_t cacheSql(std::string_view sql_query) const override {
         auto key = std::string(sql_query);
@@ -107,13 +111,17 @@ public:
         return cached_sqls_[key];
     }
 
-    void removeCacheSql(const StringMeta& sql_meta) const override {}
+    void removeCacheSql(const StringMeta& sql_meta) const override {
+        removed_sql_count_++;
+    }
 
     std::vector<unsigned char> cacheSqlUid(std::string_view sql) const override {
         return {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     }
 
-    void removeCacheSqlUid(const SqlUidMeta& sql_uid_meta) const override {}
+    void removeCacheSqlUid(const SqlUidMeta& sql_uid_meta) const override {
+        removed_sql_uid_count_++;
+    }
 
     bool isStatusFail(int status) const override {
         // Mirror AgentImpl::isStatusFail: use the configurable HttpStatusErrors
@@ -197,6 +205,10 @@ public:
     mutable int32_t api_id_counter_ = 100;
     mutable int32_t error_id_counter_ = 200;
     mutable int32_t sql_id_counter_ = 300;
+    mutable int removed_api_count_ = 0;
+    mutable int removed_error_count_ = 0;
+    mutable int removed_sql_count_ = 0;
+    mutable int removed_sql_uid_count_ = 0;
 
 private:
     bool is_exiting_;

--- a/test/test_agent_with_mocks.cpp
+++ b/test/test_agent_with_mocks.cpp
@@ -35,6 +35,8 @@
 using ::testing::_;
 using ::testing::Return;
 using ::testing::NiceMock;
+using ::testing::SetArgPointee;
+using ::testing::DoAll;
 
 namespace pinpoint {
 
@@ -50,17 +52,6 @@ public:
         EXPECT_CALL(*agent_stub, RequestAgentInfo(_, _, _))
             .WillRepeatedly(Return(grpc::Status::OK));
         set_agent_stub(std::move(agent_stub));
-
-        auto meta_stub = std::make_unique<NiceMock<v1::MockMetadataStub>>();
-        EXPECT_CALL(*meta_stub, RequestApiMetaData(_, _, _))
-            .WillRepeatedly(Return(grpc::Status::OK));
-        EXPECT_CALL(*meta_stub, RequestStringMetaData(_, _, _))
-            .WillRepeatedly(Return(grpc::Status::OK));
-        EXPECT_CALL(*meta_stub, RequestSqlMetaData(_, _, _))
-            .WillRepeatedly(Return(grpc::Status::OK));
-        EXPECT_CALL(*meta_stub, RequestSqlUidMetaData(_, _, _))
-            .WillRepeatedly(Return(grpc::Status::OK));
-        set_meta_stub(std::move(meta_stub));
     }
 
     // First call (registration) returns true, subsequent calls (workers) return false
@@ -75,6 +66,30 @@ protected:
 
 private:
     std::atomic<int> ready_count_{0};
+};
+
+class TestableGrpcMetadata : public GrpcMetadata {
+public:
+    explicit TestableGrpcMetadata(std::shared_ptr<const Config> config)
+        : GrpcMetadata(std::move(config)) {}
+
+    void injectMockStubs() {
+        v1::PResult ok;
+        ok.set_success(true);
+
+        auto meta_stub = std::make_unique<NiceMock<v1::MockMetadataStub>>();
+        EXPECT_CALL(*meta_stub, RequestApiMetaData(_, _, _))
+            .WillRepeatedly(DoAll(SetArgPointee<2>(ok), Return(grpc::Status::OK)));
+        EXPECT_CALL(*meta_stub, RequestStringMetaData(_, _, _))
+            .WillRepeatedly(DoAll(SetArgPointee<2>(ok), Return(grpc::Status::OK)));
+        EXPECT_CALL(*meta_stub, RequestSqlMetaData(_, _, _))
+            .WillRepeatedly(DoAll(SetArgPointee<2>(ok), Return(grpc::Status::OK)));
+        EXPECT_CALL(*meta_stub, RequestSqlUidMetaData(_, _, _))
+            .WillRepeatedly(DoAll(SetArgPointee<2>(ok), Return(grpc::Status::OK)));
+        set_meta_stub(std::move(meta_stub));
+    }
+
+    bool readyChannel() override { return false; }
 };
 
 class TestableGrpcSpan : public GrpcSpan {
@@ -137,16 +152,19 @@ static std::shared_ptr<Config> make_test_config() {
 
 static std::shared_ptr<AgentImpl> make_test_agent(std::shared_ptr<Config> cfg) {
     auto grpc_agent = std::make_unique<TestableGrpcAgent>(cfg);
+    auto grpc_metadata = std::make_unique<TestableGrpcMetadata>(cfg);
     auto grpc_span = std::make_unique<TestableGrpcSpan>(cfg);
     auto grpc_stat = std::make_unique<TestableGrpcStats>(cfg);
 
     grpc_agent->injectMockStubs();
+    grpc_metadata->injectMockStubs();
     grpc_span->injectMockStubs();
     grpc_stat->injectMockStubs();
 
     return std::make_shared<AgentImpl>(
         cfg,
         std::move(grpc_agent),
+        std::move(grpc_metadata),
         std::move(grpc_span),
         std::move(grpc_stat));
 }

--- a/test/test_grpc.cpp
+++ b/test/test_grpc.cpp
@@ -112,25 +112,26 @@ TEST_F(GrpcTest, GrpcAgentRegisterAgentTest) {
 }
 
 TEST_F(GrpcTest, GrpcAgentMetaOperationsTest) {
-    GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
+    GrpcMetadata metadata(mock_agent_service_->getConfig()); metadata.setAgentService(mock_agent_service_.get());
     
     // Test enqueueMeta with API metadata
     auto api_meta = std::make_unique<MetaData>(META_API, 1, 100, "test.api");
-    agent.enqueueMeta(std::move(api_meta));
+    metadata.enqueueMeta(std::move(api_meta));
     
     // Test enqueueMeta with string metadata
     auto str_meta = std::make_unique<MetaData>(META_STRING, 2, "test.string", STRING_META_ERROR);
-    agent.enqueueMeta(std::move(str_meta));
+    metadata.enqueueMeta(std::move(str_meta));
     
     SUCCEED() << "Meta enqueue operations should complete successfully";
 }
 
 TEST_F(GrpcTest, GrpcAgentWorkerOperationsTest) {
     GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
+    GrpcMetadata metadata(mock_agent_service_->getConfig()); metadata.setAgentService(mock_agent_service_.get());
     
     // Test worker stop methods (skip start workers as they block without server)
     agent.stopPingWorker();
-    agent.stopMetaWorker();
+    metadata.stopMetaWorker();
     
     SUCCEED() << "Worker stop operations should complete successfully";
 }
@@ -261,13 +262,13 @@ TEST_F(GrpcTest, GrpcClientTypeTest) {
 
 TEST_F(GrpcTest, CompleteWorkflowTest) {
     // Create all client types
-    GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
+    GrpcMetadata metadata(mock_agent_service_->getConfig()); metadata.setAgentService(mock_agent_service_.get());
     GrpcSpan span_client(mock_agent_service_->getConfig()); span_client.setAgentService(mock_agent_service_.get());
     GrpcStats stats_client(mock_agent_service_->getConfig()); stats_client.setAgentService(mock_agent_service_.get());
     
     // Enqueue some data
     auto api_meta = std::make_unique<MetaData>(META_API, 1, 100, "workflow.test");
-    agent.enqueueMeta(std::move(api_meta));
+    metadata.enqueueMeta(std::move(api_meta));
     
     auto span_data = std::make_shared<SpanData>(mock_agent_service_.get(), "workflow-test");
     auto span_chunk = std::make_unique<SpanChunk>(span_data, true);
@@ -292,8 +293,9 @@ TEST_F(GrpcTest, GrpcEnumValuesTest) {
     
     // Test ClientType enum
     EXPECT_EQ(AGENT, 0);
-    EXPECT_EQ(SPAN, 1);
-    EXPECT_EQ(STATS, 2);
+    EXPECT_EQ(METADATA, 1);
+    EXPECT_EQ(SPAN, 2);
+    EXPECT_EQ(STATS, 3);
     
     // Test MetaType enum
     EXPECT_EQ(META_API, 0);
@@ -448,22 +450,22 @@ TEST_F(GrpcTest, MetaTypeEnumValuesTest) {
 // Queue behavior tests
 
 TEST_F(GrpcTest, GrpcAgentMultipleMetaEnqueueTest) {
-    GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
+    GrpcMetadata metadata(mock_agent_service_->getConfig()); metadata.setAgentService(mock_agent_service_.get());
 
     // Enqueue multiple different metadata types
-    agent.enqueueMeta(std::make_unique<MetaData>(META_API, 1, 100, "api1"));
-    agent.enqueueMeta(std::make_unique<MetaData>(META_API, 2, 100, "api2"));
-    agent.enqueueMeta(std::make_unique<MetaData>(META_STRING, 3, "err1", STRING_META_ERROR));
-    agent.enqueueMeta(std::make_unique<MetaData>(META_STRING, 4, "sql1", STRING_META_SQL));
+    metadata.enqueueMeta(std::make_unique<MetaData>(META_API, 1, 100, "api1"));
+    metadata.enqueueMeta(std::make_unique<MetaData>(META_API, 2, 100, "api2"));
+    metadata.enqueueMeta(std::make_unique<MetaData>(META_STRING, 3, "err1", STRING_META_ERROR));
+    metadata.enqueueMeta(std::make_unique<MetaData>(META_STRING, 4, "sql1", STRING_META_SQL));
 
     std::vector<unsigned char> uid = {1, 2, 3};
-    agent.enqueueMeta(std::make_unique<MetaData>(META_SQL_UID, uid, "SELECT 1"));
+    metadata.enqueueMeta(std::make_unique<MetaData>(META_SQL_UID, uid, "SELECT 1"));
 
     TraceId txid{"agent", 100, 0};
     std::vector<std::unique_ptr<Exception>> exceptions;
     auto cs = std::make_unique<CallStack>("test");
     exceptions.push_back(std::make_unique<Exception>(std::move(cs)));
-    agent.enqueueMeta(std::make_unique<MetaData>(META_EXCEPTION, txid, 1, "/url", std::move(exceptions)));
+    metadata.enqueueMeta(std::make_unique<MetaData>(META_EXCEPTION, txid, 1, "/url", std::move(exceptions)));
 
     SUCCEED() << "Enqueuing multiple meta types should succeed";
 }
@@ -506,11 +508,12 @@ TEST_F(GrpcTest, GrpcClientCloseChannelIdempotentTest) {
 
 TEST_F(GrpcTest, GrpcAgentStopWorkersIdempotentTest) {
     GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
+    GrpcMetadata metadata(mock_agent_service_->getConfig()); metadata.setAgentService(mock_agent_service_.get());
 
     agent.stopPingWorker();
     agent.stopPingWorker();
-    agent.stopMetaWorker();
-    agent.stopMetaWorker();
+    metadata.stopMetaWorker();
+    metadata.stopMetaWorker();
 
     SUCCEED() << "Stopping workers multiple times should be safe";
 }
@@ -575,11 +578,11 @@ TEST_F(GrpcTest, StringMetaLongSqlTest) {
 // Enqueue after service exiting
 
 TEST_F(GrpcTest, GrpcAgentEnqueueMetaWhileExitingTest) {
-    GrpcAgent agent(mock_agent_service_->getConfig()); agent.setAgentService(mock_agent_service_.get());
+    GrpcMetadata metadata(mock_agent_service_->getConfig()); metadata.setAgentService(mock_agent_service_.get());
     mock_agent_service_->setExiting(true);
 
     // Should not crash even when service is exiting
-    agent.enqueueMeta(std::make_unique<MetaData>(META_API, 1, 100, "api-during-exit"));
+    metadata.enqueueMeta(std::make_unique<MetaData>(META_API, 1, 100, "api-during-exit"));
 
     SUCCEED() << "Enqueuing meta while exiting should not crash";
 }
@@ -627,4 +630,3 @@ TEST_F(GrpcTest, MetaValueVariantIndexTest) {
 // The callbacks are tested indirectly through the actual gRPC operations in integration tests
 
 } // namespace pinpoint
-

--- a/test/test_grpc_with_mocks.cpp
+++ b/test/test_grpc_with_mocks.cpp
@@ -41,6 +41,12 @@ using ::testing::SetArgPointee;
 
 namespace pinpoint {
 
+static v1::PResult success_result() {
+    v1::PResult result;
+    result.set_success(true);
+    return result;
+}
+
 // Mock Writer Interface for gRPC streams
 class MockClientWriter : public grpc::ClientWriterInterface<v1::PSpanMessage> {
 public:
@@ -71,10 +77,30 @@ public:
 };
 
 // Testable gRPC classes that inject mock stubs
+class TestableGrpcMetadata : public GrpcMetadata {
+public:
+    explicit TestableGrpcMetadata(AgentService* agent) : GrpcMetadata(agent->getConfig()) {
+        setAgentService(agent);
+    }
+
+    void setMockMetaStub(std::unique_ptr<v1::MockMetadataStub> mock_stub) {
+        set_meta_stub(std::move(mock_stub));
+    }
+
+    bool readyChannel() override {
+        return ready_channel_;
+    }
+
+    void setReadyChannel(bool ready) { ready_channel_ = ready; }
+
+private:
+    bool ready_channel_{true};
+};
+
 class TestableGrpcAgent : public GrpcAgent {
 public:
-    explicit TestableGrpcAgent(AgentService* agent) : GrpcAgent(agent->getConfig()) {
-        agent_ = agent;
+    explicit TestableGrpcAgent(AgentService* agent) : GrpcAgent(agent->getConfig()), metadata_(agent) {
+        setAgentService(agent);
     }
 
     void setMockAgentStub(std::unique_ptr<v1::MockAgentStub> mock_stub) {
@@ -82,7 +108,19 @@ public:
     }
 
     void setMockMetaStub(std::unique_ptr<v1::MockMetadataStub> mock_stub) {
-        set_meta_stub(std::move(mock_stub));
+        metadata_.setMockMetaStub(std::move(mock_stub));
+    }
+
+    void enqueueMeta(std::unique_ptr<MetaData> meta) noexcept {
+        metadata_.enqueueMeta(std::move(meta));
+    }
+
+    void sendMetaWorker() {
+        metadata_.sendMetaWorker();
+    }
+
+    void stopMetaWorker() {
+        metadata_.stopMetaWorker();
     }
 
     // Override readyChannel — controllable per-test
@@ -90,13 +128,17 @@ public:
         return ready_channel_;
     }
 
-    void setReadyChannel(bool ready) { ready_channel_ = ready; }
+    void setReadyChannel(bool ready) {
+        ready_channel_ = ready;
+        metadata_.setReadyChannel(ready);
+    }
 
 protected:
     bool wait_channel_ready() const { return true; }
 
 private:
     bool ready_channel_{true};
+    TestableGrpcMetadata metadata_;
 };
 
 class TestableGrpcSpan : public GrpcSpan {
@@ -272,10 +314,10 @@ TEST_F(GrpcMockTest, GrpcAgentMetaWorkerTest) {
     
     // Set up expectations for metadata operations
     EXPECT_CALL(*mock_meta_stub, RequestApiMetaData(_, _, _))
-        .WillOnce(Return(grpc::Status::OK));
+        .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
     
     EXPECT_CALL(*mock_meta_stub, RequestStringMetaData(_, _, _))
-        .WillOnce(Return(grpc::Status::OK));
+        .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
     
     agent.setMockMetaStub(std::move(mock_meta_stub));
     
@@ -442,7 +484,7 @@ TEST_F(GrpcMockTest, CompleteGrpcWorkflowWithWorkersTest) {
     
     // Metadata expectations (these might succeed if worker processes queue before connection)
     EXPECT_CALL(*mock_meta_stub, RequestApiMetaData(_, _, _))
-        .WillRepeatedly(Return(grpc::Status::OK));
+        .WillRepeatedly(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
     
     // Span expectations (gRPC connection will fail)  
     EXPECT_CALL(*mock_span_stub, SendSpanRaw(_, _))
@@ -727,13 +769,13 @@ TEST_F(GrpcMockTest, GrpcAgentMetaWorkerMixedSuccessFailureTest) {
         InSequence seq;
         // First API meta succeeds
         EXPECT_CALL(*mock_meta_stub, RequestApiMetaData(_, _, _))
-            .WillOnce(Return(grpc::Status::OK));
+            .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
         // Second API meta fails
         EXPECT_CALL(*mock_meta_stub, RequestApiMetaData(_, _, _))
             .WillOnce(Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "unavailable")));
         // Third API meta succeeds (recovery after failure)
         EXPECT_CALL(*mock_meta_stub, RequestApiMetaData(_, _, _))
-            .WillOnce(Return(grpc::Status::OK));
+            .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
     }
 
     agent.setMockMetaStub(std::move(mock_meta_stub));
@@ -751,6 +793,53 @@ TEST_F(GrpcMockTest, GrpcAgentMetaWorkerMixedSuccessFailureTest) {
     if (meta_worker.joinable()) meta_worker.join();
 
     SUCCEED() << "Worker should continue processing after a failure";
+}
+
+TEST_F(GrpcMockTest, GrpcMetadataRetriesFailedResultWithoutEvictingCache) {
+    TestableGrpcMetadata metadata(mock_agent_service_.get());
+
+    v1::PResult failed;
+    failed.set_success(false);
+
+    auto mock_meta_stub = std::make_unique<NiceMock<v1::MockMetadataStub>>();
+    EXPECT_CALL(*mock_meta_stub, RequestApiMetaData(_, _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(failed), Return(grpc::Status::OK)))
+        .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
+
+    metadata.setMockMetaStub(std::move(mock_meta_stub));
+    metadata.enqueueMeta(std::make_unique<MetaData>(META_API, 1, 100, "api.retry"));
+
+    std::thread meta_worker([&metadata]() { metadata.sendMetaWorker(); });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+    mock_agent_service_->setExiting(true);
+    metadata.stopMetaWorker();
+
+    if (meta_worker.joinable()) meta_worker.join();
+
+    EXPECT_EQ(mock_agent_service_->removed_api_count_, 0);
+}
+
+TEST_F(GrpcMockTest, GrpcMetadataEvictsCacheAfterRetryExhaustion) {
+    TestableGrpcMetadata metadata(mock_agent_service_.get());
+
+    auto mock_meta_stub = std::make_unique<NiceMock<v1::MockMetadataStub>>();
+    EXPECT_CALL(*mock_meta_stub, RequestApiMetaData(_, _, _))
+        .Times(4)
+        .WillRepeatedly(Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "unavailable")));
+
+    metadata.setMockMetaStub(std::move(mock_meta_stub));
+    metadata.enqueueMeta(std::make_unique<MetaData>(META_API, 1, 100, "api.exhaust"));
+
+    std::thread meta_worker([&metadata]() { metadata.sendMetaWorker(); });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(3600));
+    mock_agent_service_->setExiting(true);
+    metadata.stopMetaWorker();
+
+    if (meta_worker.joinable()) meta_worker.join();
+
+    EXPECT_EQ(mock_agent_service_->removed_api_count_, 1);
 }
 
 // ============================================================
@@ -822,15 +911,15 @@ TEST_F(GrpcMockTest, GrpcAgentMetaWorkerAllTypesSuccessTest) {
     auto mock_meta_stub = std::make_unique<NiceMock<v1::MockMetadataStub>>();
 
     EXPECT_CALL(*mock_meta_stub, RequestApiMetaData(_, _, _))
-        .WillOnce(Return(grpc::Status::OK));
+        .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
     EXPECT_CALL(*mock_meta_stub, RequestStringMetaData(_, _, _))
-        .WillOnce(Return(grpc::Status::OK));
+        .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
     EXPECT_CALL(*mock_meta_stub, RequestSqlMetaData(_, _, _))
-        .WillOnce(Return(grpc::Status::OK));
+        .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
     EXPECT_CALL(*mock_meta_stub, RequestSqlUidMetaData(_, _, _))
-        .WillOnce(Return(grpc::Status::OK));
+        .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
     EXPECT_CALL(*mock_meta_stub, RequestExceptionMetaData(_, _, _))
-        .WillOnce(Return(grpc::Status::OK));
+        .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
 
     agent.setMockMetaStub(std::move(mock_meta_stub));
 
@@ -949,7 +1038,7 @@ TEST_F(GrpcMockTest, GrpcAgentSendSqlMetaSuccessTest) {
     auto mock_meta_stub = std::make_unique<NiceMock<v1::MockMetadataStub>>();
 
     EXPECT_CALL(*mock_meta_stub, RequestSqlMetaData(_, _, _))
-        .WillOnce(Return(grpc::Status::OK));
+        .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
 
     agent.setMockMetaStub(std::move(mock_meta_stub));
 
@@ -972,7 +1061,7 @@ TEST_F(GrpcMockTest, GrpcAgentSendSqlUidMetaSuccessTest) {
     auto mock_meta_stub = std::make_unique<NiceMock<v1::MockMetadataStub>>();
 
     EXPECT_CALL(*mock_meta_stub, RequestSqlUidMetaData(_, _, _))
-        .WillOnce(Return(grpc::Status::OK));
+        .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
 
     agent.setMockMetaStub(std::move(mock_meta_stub));
 
@@ -996,7 +1085,7 @@ TEST_F(GrpcMockTest, GrpcAgentSendExceptionMetaSuccessTest) {
     auto mock_meta_stub = std::make_unique<NiceMock<v1::MockMetadataStub>>();
 
     EXPECT_CALL(*mock_meta_stub, RequestExceptionMetaData(_, _, _))
-        .WillOnce(Return(grpc::Status::OK));
+        .WillOnce(DoAll(SetArgPointee<2>(success_result()), Return(grpc::Status::OK)));
 
     agent.setMockMetaStub(std::move(mock_meta_stub));
 
@@ -1042,4 +1131,3 @@ TEST_F(GrpcMockTest, GrpcAgentMultipleRegisterTest) {
 }
 
 } // namespace pinpoint
-

--- a/test/test_tracer_c.cpp
+++ b/test/test_tracer_c.cpp
@@ -50,6 +50,8 @@
 using ::testing::_;
 using ::testing::NiceMock;
 using ::testing::Return;
+using ::testing::DoAll;
+using ::testing::SetArgPointee;
 
 // ============================================================================
 // Mock gRPC infrastructure (same pattern as test_agent_with_mocks.cpp)
@@ -67,17 +69,6 @@ public:
         EXPECT_CALL(*agent_stub, RequestAgentInfo(_, _, _))
             .WillRepeatedly(Return(grpc::Status::OK));
         set_agent_stub(std::move(agent_stub));
-
-        auto meta_stub = std::make_unique<NiceMock<v1::MockMetadataStub>>();
-        EXPECT_CALL(*meta_stub, RequestApiMetaData(_, _, _))
-            .WillRepeatedly(Return(grpc::Status::OK));
-        EXPECT_CALL(*meta_stub, RequestStringMetaData(_, _, _))
-            .WillRepeatedly(Return(grpc::Status::OK));
-        EXPECT_CALL(*meta_stub, RequestSqlMetaData(_, _, _))
-            .WillRepeatedly(Return(grpc::Status::OK));
-        EXPECT_CALL(*meta_stub, RequestSqlUidMetaData(_, _, _))
-            .WillRepeatedly(Return(grpc::Status::OK));
-        set_meta_stub(std::move(meta_stub));
     }
 
     bool readyChannel() override { return ready_count_++ == 0; }
@@ -85,6 +76,30 @@ public:
 
 private:
     std::atomic<int> ready_count_{0};
+};
+
+class TestableGrpcMetadata : public pinpoint::GrpcMetadata {
+public:
+    explicit TestableGrpcMetadata(std::shared_ptr<const pinpoint::Config> cfg)
+        : GrpcMetadata(std::move(cfg)) {}
+
+    void injectMockStubs() {
+        v1::PResult ok;
+        ok.set_success(true);
+
+        auto meta_stub = std::make_unique<NiceMock<v1::MockMetadataStub>>();
+        EXPECT_CALL(*meta_stub, RequestApiMetaData(_, _, _))
+            .WillRepeatedly(DoAll(SetArgPointee<2>(ok), Return(grpc::Status::OK)));
+        EXPECT_CALL(*meta_stub, RequestStringMetaData(_, _, _))
+            .WillRepeatedly(DoAll(SetArgPointee<2>(ok), Return(grpc::Status::OK)));
+        EXPECT_CALL(*meta_stub, RequestSqlMetaData(_, _, _))
+            .WillRepeatedly(DoAll(SetArgPointee<2>(ok), Return(grpc::Status::OK)));
+        EXPECT_CALL(*meta_stub, RequestSqlUidMetaData(_, _, _))
+            .WillRepeatedly(DoAll(SetArgPointee<2>(ok), Return(grpc::Status::OK)));
+        set_meta_stub(std::move(meta_stub));
+    }
+
+    bool readyChannel() override { return false; }
 };
 
 class TestableGrpcSpan : public pinpoint::GrpcSpan {
@@ -136,16 +151,19 @@ static std::shared_ptr<pinpoint::Config> make_test_config() {
 static std::shared_ptr<pinpoint::AgentImpl> make_test_agent(
         std::shared_ptr<pinpoint::Config> cfg) {
     auto grpc_agent = std::make_unique<TestableGrpcAgent>(cfg);
+    auto grpc_metadata = std::make_unique<TestableGrpcMetadata>(cfg);
     auto grpc_span  = std::make_unique<TestableGrpcSpan>(cfg);
     auto grpc_stat  = std::make_unique<TestableGrpcStats>(cfg);
 
     grpc_agent->injectMockStubs();
+    grpc_metadata->injectMockStubs();
     grpc_span->injectMockStubs();
     grpc_stat->injectMockStubs();
 
     return std::make_shared<pinpoint::AgentImpl>(
         cfg,
         std::move(grpc_agent),
+        std::move(grpc_metadata),
         std::move(grpc_span),
         std::move(grpc_stat));
 }


### PR DESCRIPTION
## Summary
- Split metadata upload out of `GrpcAgent` into a dedicated `GrpcMetadata` client derived from `GrpcClient`.
- Wire `AgentImpl` to own and run the metadata sender separately from agent registration and ping.
- Retry metadata sends on RPC failure or `PResult.success=false`, preserving cache entries until retry exhaustion.
- Cover API, string/error SQL, SQL UID, and exception metadata in the separated sender.

## Validation
- `cmake --preset debug-cached`
- `cmake --build --preset debug-cached`
- `build/debug-cached/test/test_grpc`
- `build/debug-cached/test/test_grpc_with_mocks`

Note: this worktree does not contain `scripts/dev-shell.sh`, so the approved `source scripts/dev-shell.sh; ...` wrapper emitted a shell warning, but CMake configure/build completed successfully.

## Java parity notes
- The C++ sender uses conservative defaults: 3 retries with 1 second delay.
- Java optional gRPC hedging is not implemented here because there is no matching C++ config/hook yet.

Closes #77