### PR TITLE
[#79] Integrate AgentInfo scheduling into GrpcAgent

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -170,6 +170,10 @@ namespace pinpoint {
 
         // Rebuild header recorders
         init_header_recorders(local_cfg);
+
+        if (grpc_agent_) {
+            grpc_agent_->refreshAgentInfo();
+        }
     }
 
     void AgentImpl::init_grpc_workers() try {
@@ -177,11 +181,7 @@ namespace pinpoint {
         grpc_span_->setAgentService(this);
         grpc_stat_->setAgentService(this);
 
-        do {
-            if (!grpc_agent_->readyChannel()) {
-                return;
-            }
-        } while (grpc_agent_->registerAgent() != SEND_OK);
+        grpc_agent_->startAgentInfo();
 
         ping_thread_ = std::thread{&GrpcAgent::sendPingWorker, grpc_agent_.get()};
         meta_thread_ = std::thread{&GrpcAgent::sendMetaWorker, grpc_agent_.get()};
@@ -190,15 +190,18 @@ namespace pinpoint {
         url_stat_add_thread_ = std::thread{&UrlStats::addUrlStatsWorker, url_stats_.get()};
         url_stat_send_thread_ = std::thread{&UrlStats::sendUrlStatsWorker, url_stats_.get()};
         agent_stat_thread_ = std::thread{&AgentStats::agentStatsWorker, agent_stats_.get()};
-
-        enabled_ = true;
     } catch (const std::exception &e) {
         LOG_ERROR("failed to init grpc workers: exception = {}", e.what());
         enabled_ = false;
         return;
     }
 
+    void AgentImpl::onAgentInfoSent() {
+        enabled_ = true;
+    }
+
     void AgentImpl::close_grpc_workers() {
+        grpc_agent_->stopAgentInfo();
         url_stats_->stopAddUrlStatsWorker();
         url_stats_->stopSendUrlStatsWorker();
         agent_stats_->stopAgentStatsWorker();

--- a/src/agent.h
+++ b/src/agent.h
@@ -92,6 +92,7 @@ namespace pinpoint {
     	int64_t getStartTime() const override { return start_time_; }
 		/// @brief Reloads configuration-dependent helpers (samplers, filters, recorders).
     	void reloadConfig(std::shared_ptr<const Config> cfg) override;
+    	void onAgentInfoSent() override;
 
     	TraceId generateTraceId() override;
     	void recordSpan(std::unique_ptr<SpanChunk> span) const override;
@@ -169,4 +170,3 @@ namespace pinpoint {
     void reset_global_agent();
 
 }  // namespace pinpoint
-

--- a/src/agent_service.h
+++ b/src/agent_service.h
@@ -70,6 +70,9 @@
       virtual int64_t getStartTime() const = 0;
       /// @brief Reloads configuration-dependent helpers (samplers, filters, recorders).
       virtual void reloadConfig(std::shared_ptr<const Config> cfg) = 0;
+
+      /// @brief Called after the first successful AgentInfo send enables data recording.
+      virtual void onAgentInfoSent() {}
  
       /**
        * @brief Generates a new distributed trace identifier.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -303,6 +303,12 @@ namespace pinpoint {
             }
         }
 
+        if (auto& agent_info = yaml["AgentInfo"]) {
+            config.agent_info.refresh_interval_ms = get_int(agent_info, "RefreshIntervalMs", defaults::AGENT_INFO_REFRESH_INTERVAL_MS);
+            config.agent_info.send_retry_interval_ms = get_int(agent_info, "SendRetryIntervalMs", defaults::AGENT_INFO_SEND_RETRY_INTERVAL_MS);
+            config.agent_info.max_try_per_attempt = get_int(agent_info, "MaxTryPerAttempt", defaults::AGENT_INFO_MAX_TRY_PER_ATTEMPT);
+        }
+
         if (yaml["IsContainer"]) {
             config.is_container = get_boolean(yaml, "IsContainer", false);
             is_container_set = true;
@@ -438,6 +444,15 @@ namespace pinpoint {
         }
         if(const char* env_p = std::getenv(env::SPAN_BATCH_MAX_CONCURRENT_REQUESTS)) {
             config.span.batch.max_concurrent_requests = safe_env_stoi(env::SPAN_BATCH_MAX_CONCURRENT_REQUESTS, env_p, defaults::SPAN_BATCH_MAX_CONCURRENT_REQUESTS);
+        }
+        if(const char* env_p = std::getenv(env::AGENT_INFO_REFRESH_INTERVAL_MS)) {
+            config.agent_info.refresh_interval_ms = safe_env_stoi(env::AGENT_INFO_REFRESH_INTERVAL_MS, env_p, defaults::AGENT_INFO_REFRESH_INTERVAL_MS);
+        }
+        if(const char* env_p = std::getenv(env::AGENT_INFO_SEND_RETRY_INTERVAL_MS)) {
+            config.agent_info.send_retry_interval_ms = safe_env_stoi(env::AGENT_INFO_SEND_RETRY_INTERVAL_MS, env_p, defaults::AGENT_INFO_SEND_RETRY_INTERVAL_MS);
+        }
+        if(const char* env_p = std::getenv(env::AGENT_INFO_MAX_TRY_PER_ATTEMPT)) {
+            config.agent_info.max_try_per_attempt = safe_env_stoi(env::AGENT_INFO_MAX_TRY_PER_ATTEMPT, env_p, defaults::AGENT_INFO_MAX_TRY_PER_ATTEMPT);
         }
 
         if(const char* env_p = std::getenv(env::IS_CONTAINER)) {
@@ -713,6 +728,21 @@ namespace pinpoint {
                      config->span.batch.max_concurrent_requests, defaults::SPAN_BATCH_MAX_CONCURRENT_REQUESTS);
             config->span.batch.max_concurrent_requests = defaults::SPAN_BATCH_MAX_CONCURRENT_REQUESTS;
         }
+        if (config->agent_info.refresh_interval_ms < 1) {
+            LOG_WARN("agent info refresh interval {}ms is invalid, using default: {}ms",
+                     config->agent_info.refresh_interval_ms, defaults::AGENT_INFO_REFRESH_INTERVAL_MS);
+            config->agent_info.refresh_interval_ms = defaults::AGENT_INFO_REFRESH_INTERVAL_MS;
+        }
+        if (config->agent_info.send_retry_interval_ms < 1) {
+            LOG_WARN("agent info send retry interval {}ms is invalid, using default: {}ms",
+                     config->agent_info.send_retry_interval_ms, defaults::AGENT_INFO_SEND_RETRY_INTERVAL_MS);
+            config->agent_info.send_retry_interval_ms = defaults::AGENT_INFO_SEND_RETRY_INTERVAL_MS;
+        }
+        if (config->agent_info.max_try_per_attempt < 1) {
+            LOG_WARN("agent info max try per attempt {} is invalid, using default: {}",
+                     config->agent_info.max_try_per_attempt, defaults::AGENT_INFO_MAX_TRY_PER_ATTEMPT);
+            config->agent_info.max_try_per_attempt = defaults::AGENT_INFO_MAX_TRY_PER_ATTEMPT;
+        }
 
         if (!is_container_set) {
             config->is_container = is_container_env();
@@ -778,6 +808,13 @@ namespace pinpoint {
         emitter << YAML::Key << "CollectDeadlineMs" << YAML::Value << config.span.batch.collect_deadline_ms;
         emitter << YAML::Key << "MaxConcurrentRequests" << YAML::Value << config.span.batch.max_concurrent_requests;
         emitter << YAML::EndMap;
+        emitter << YAML::EndMap;
+
+        emitter << YAML::Key << "AgentInfo";
+        emitter << YAML::BeginMap;
+        emitter << YAML::Key << "RefreshIntervalMs" << YAML::Value << config.agent_info.refresh_interval_ms;
+        emitter << YAML::Key << "SendRetryIntervalMs" << YAML::Value << config.agent_info.send_retry_interval_ms;
+        emitter << YAML::Key << "MaxTryPerAttempt" << YAML::Value << config.agent_info.max_try_per_attempt;
         emitter << YAML::EndMap;
 
         emitter << YAML::Key << "Http";

--- a/src/config.h
+++ b/src/config.h
@@ -41,6 +41,9 @@ namespace pinpoint {
         constexpr int SPAN_BATCH_FLUSH_INTERVAL_MS = 1000;
         constexpr int SPAN_BATCH_COLLECT_DEADLINE_MS = 500;
         constexpr int SPAN_BATCH_MAX_CONCURRENT_REQUESTS = 10;
+        constexpr int AGENT_INFO_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
+        constexpr int AGENT_INFO_SEND_RETRY_INTERVAL_MS = 3000;
+        constexpr int AGENT_INFO_MAX_TRY_PER_ATTEMPT = 3;
         constexpr int HTTP_URL_STAT_LIMIT = 1024;
         constexpr int SQL_MAX_BIND_ARGS_SIZE = 1024;
         constexpr int LOG_MAX_FILE_SIZE_MB = 10;
@@ -83,6 +86,9 @@ namespace pinpoint {
         constexpr const char* SPAN_BATCH_FLUSH_INTERVAL_MS = "PINPOINT_CPP_SPAN_BATCH_FLUSH_INTERVAL_MS";
         constexpr const char* SPAN_BATCH_COLLECT_DEADLINE_MS = "PINPOINT_CPP_SPAN_BATCH_COLLECT_DEADLINE_MS";
         constexpr const char* SPAN_BATCH_MAX_CONCURRENT_REQUESTS = "PINPOINT_CPP_SPAN_BATCH_MAX_CONCURRENT_REQUESTS";
+        constexpr const char* AGENT_INFO_REFRESH_INTERVAL_MS = "PINPOINT_CPP_AGENT_INFO_REFRESH_INTERVAL_MS";
+        constexpr const char* AGENT_INFO_SEND_RETRY_INTERVAL_MS = "PINPOINT_CPP_AGENT_INFO_SEND_RETRY_INTERVAL_MS";
+        constexpr const char* AGENT_INFO_MAX_TRY_PER_ATTEMPT = "PINPOINT_CPP_AGENT_INFO_MAX_TRY_PER_ATTEMPT";
         constexpr const char* IS_CONTAINER = "PINPOINT_CPP_IS_CONTAINER";
         constexpr const char* HTTP_COLLECT_URL_STAT = "PINPOINT_CPP_HTTP_COLLECT_URL_STAT";
         constexpr const char* HTTP_URL_STAT_LIMIT = "PINPOINT_CPP_HTTP_URL_STAT_LIMIT";
@@ -160,6 +166,12 @@ namespace pinpoint {
                 int max_concurrent_requests = defaults::SPAN_BATCH_MAX_CONCURRENT_REQUESTS;
             } batch;
         } span;
+
+        struct {
+            int refresh_interval_ms = defaults::AGENT_INFO_REFRESH_INTERVAL_MS;
+            int send_retry_interval_ms = defaults::AGENT_INFO_SEND_RETRY_INTERVAL_MS;
+            int max_try_per_attempt = defaults::AGENT_INFO_MAX_TRY_PER_ATTEMPT;
+        } agent_info;
 
         struct {
             struct {

--- a/src/grpc.cpp
+++ b/src/grpc.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <cassert>
+#include <limits>
 #include <memory>
 #include <string>
 #include <unistd.h>
@@ -469,10 +470,15 @@ namespace pinpoint {
         set_meta_stub(v1::Metadata::NewStub(channel_));
     }
 
-    constexpr auto REGISTER_TIMEOUT = std::chrono::seconds(60);
+    GrpcAgent::~GrpcAgent() {
+        stopAgentInfo();
+    }
+
+    constexpr auto REGISTER_TIMEOUT = std::chrono::milliseconds(defaults::AGENT_INFO_SEND_RETRY_INTERVAL_MS);
     constexpr auto META_TIMEOUT = std::chrono::seconds(5);
 
-    static void set_deadline(grpc::ClientContext& ctx, const std::chrono::seconds timeout) {
+    template<typename Rep, typename Period>
+    static void set_deadline(grpc::ClientContext& ctx, const std::chrono::duration<Rep, Period> timeout) {
         auto deadline = std::chrono::system_clock::now() + timeout;
         ctx.set_deadline(deadline);
     }
@@ -513,6 +519,116 @@ namespace pinpoint {
 
         LOG_ERROR("failed to register the agent: {}, {}", static_cast<int>(status.error_code()), status.error_message());
         return SEND_FAIL;
+    }
+
+    void GrpcAgent::startAgentInfo() {
+        std::unique_lock<std::mutex> lock(agent_info_mutex_);
+        if (agent_info_running_) {
+            return;
+        }
+        agent_info_stop_requested_ = false;
+        agent_info_refresh_requested_ = false;
+        agent_info_running_ = true;
+        agent_info_thread_ = std::thread{&GrpcAgent::agent_info_worker, this};
+    }
+
+    void GrpcAgent::stopAgentInfo() {
+        {
+            std::unique_lock<std::mutex> lock(agent_info_mutex_);
+            if (!agent_info_running_ && !agent_info_thread_.joinable()) {
+                return;
+            }
+            agent_info_stop_requested_ = true;
+            agent_info_cv_.notify_all();
+        }
+        if (agent_info_thread_.joinable()) {
+            agent_info_thread_.join();
+        }
+        {
+            std::unique_lock<std::mutex> lock(agent_info_mutex_);
+            agent_info_running_ = false;
+            agent_info_refresh_requested_ = false;
+        }
+        LOG_INFO("AgentInfo scheduler stopped");
+    }
+
+    void GrpcAgent::refreshAgentInfo() {
+        std::unique_lock<std::mutex> lock(agent_info_mutex_);
+        if (!agent_info_running_) {
+            return;
+        }
+        agent_info_refresh_requested_ = true;
+        agent_info_cv_.notify_all();
+    }
+
+    bool GrpcAgent::should_stop_agent_info() const {
+        return agent_info_stop_requested_ || agent_->isExiting();
+    }
+
+    bool GrpcAgent::send_agent_info_once() {
+        if (agent_->isExiting()) {
+            return false;
+        }
+        const auto status = registerAgent();
+        if (status == SEND_OK) {
+            LOG_INFO("AgentInfo sent");
+            agent_->onAgentInfoSent();
+            return true;
+        }
+        LOG_WARN("failed to send AgentInfo");
+        return false;
+    }
+
+    bool GrpcAgent::send_agent_info_with_retries(const int max_try_count) {
+        const auto retry_interval = std::chrono::milliseconds(config_->agent_info.send_retry_interval_ms);
+        for (int try_count = 0; try_count < max_try_count; ++try_count) {
+            if (agent_->isExiting()) {
+                return false;
+            }
+            if (send_agent_info_once()) {
+                return true;
+            }
+            if (try_count + 1 < max_try_count && wait_agent_info_retry(retry_interval)) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    bool GrpcAgent::wait_agent_info_retry(std::chrono::milliseconds delay) {
+        std::unique_lock<std::mutex> lock(agent_info_mutex_);
+        agent_info_cv_.wait_for(lock, delay, [this] { return should_stop_agent_info() || agent_info_refresh_requested_; });
+        return should_stop_agent_info();
+    }
+
+    bool GrpcAgent::wait_agent_info_until(std::chrono::steady_clock::time_point deadline) {
+        std::unique_lock<std::mutex> lock(agent_info_mutex_);
+        agent_info_cv_.wait_until(lock, deadline, [this] { return should_stop_agent_info() || agent_info_refresh_requested_; });
+        return should_stop_agent_info();
+    }
+
+    void GrpcAgent::agent_info_worker() try {
+        if (!send_agent_info_with_retries(std::numeric_limits<int>::max())) {
+            return;
+        }
+
+        const auto refresh_interval = std::chrono::milliseconds(config_->agent_info.refresh_interval_ms);
+        auto next_refresh = std::chrono::steady_clock::now() + refresh_interval;
+        while (true) {
+            if (wait_agent_info_until(next_refresh)) {
+                return;
+            }
+
+            {
+                std::unique_lock<std::mutex> lock(agent_info_mutex_);
+                agent_info_refresh_requested_ = false;
+            }
+
+            send_agent_info_with_retries(config_->agent_info.max_try_per_attempt);
+            next_refresh = std::chrono::steady_clock::now() + refresh_interval;
+        }
+    } catch (const std::exception& e) {
+        LOG_ERROR("AgentInfo scheduler exception = {}", e.what());
     }
 
     template<typename Request, typename StubMethod>

--- a/src/grpc.h
+++ b/src/grpc.h
@@ -23,6 +23,7 @@
 #include <mutex>
 #include <queue>
 #include <string>
+#include <thread>
 #include <variant>
 #include <vector>
 
@@ -203,6 +204,7 @@ namespace pinpoint {
     class GrpcAgent : public GrpcClient, public grpc::ClientBidiReactor<v1::PPing, v1::PPing> {
     public:
         explicit GrpcAgent(std::shared_ptr<const Config> config);
+        ~GrpcAgent() override;
 
         /**
          * @brief Registers the agent with the collector and starts ping streaming.
@@ -223,6 +225,12 @@ namespace pinpoint {
         void sendMetaWorker();
         /// @brief Stops the metadata worker loop.
         void stopMetaWorker();
+        /// @brief Starts the scheduled AgentInfo sender loop.
+        void startAgentInfo();
+        /// @brief Stops the scheduled AgentInfo sender loop.
+        void stopAgentInfo();
+        /// @brief Requests an immediate AgentInfo refresh attempt.
+        void refreshAgentInfo();
 
         //grpc::ClientBidiReactor
         /// @brief Notification invoked after each write completes.
@@ -249,9 +257,23 @@ namespace pinpoint {
         std::mutex meta_queue_mutex_{};
         std::condition_variable meta_queue_cv_{};
 
+        std::thread agent_info_thread_;
+        std::mutex agent_info_mutex_;
+        std::condition_variable agent_info_cv_;
+        bool agent_info_running_{false};
+        bool agent_info_stop_requested_{false};
+        bool agent_info_refresh_requested_{false};
+
         bool start_ping_stream();
         void finish_ping_stream();
         GrpcStreamStatus write_and_await_ping_stream();
+
+        void agent_info_worker();
+        bool send_agent_info_once();
+        bool send_agent_info_with_retries(int max_try_count);
+        bool wait_agent_info_retry(std::chrono::milliseconds delay);
+        bool wait_agent_info_until(std::chrono::steady_clock::time_point deadline);
+        bool should_stop_agent_info() const;
 
         template<typename Request, typename StubMethod>
         GrpcRequestStatus send_meta_helper(StubMethod stub_method, Request& request, std::string_view operation_name);

--- a/test/test_agent_with_mocks.cpp
+++ b/test/test_agent_with_mocks.cpp
@@ -63,9 +63,8 @@ public:
         set_meta_stub(std::move(meta_stub));
     }
 
-    // First call (registration) returns true, subsequent calls (workers) return false
-    // to avoid real gRPC async streaming.
-    bool readyChannel() override { return ready_count_++ == 0; }
+    // Avoid real gRPC async streaming in worker threads.
+    bool readyChannel() override { return false; }
 
     // Override to skip real build_agent_info (which calls slow DNS resolution)
     GrpcRequestStatus registerAgent() override { return SEND_OK; }
@@ -73,8 +72,6 @@ public:
 protected:
     bool wait_channel_ready() const { return true; }
 
-private:
-    std::atomic<int> ready_count_{0};
 };
 
 class TestableGrpcSpan : public GrpcSpan {
@@ -158,7 +155,7 @@ protected:
     void SetUp() override {
         cfg_ = make_test_config();
         agent_ = make_test_agent(cfg_);
-        // Wait for init_grpc_workers thread to finish and set enabled_
+        // Wait for the initial AgentInfo send to succeed and enable the agent.
         wait_until_enabled();
     }
 
@@ -473,8 +470,7 @@ TEST_F(AgentImplDisabledTest, DisabledConfigReturnsNotEnabled) {
     cfg->sampling.counter_rate = 0;
     auto agent = make_test_agent(cfg);
 
-    // Even after init, sampling rate 0 means no spans are sampled,
-    // but the agent itself is still enabled
+    // Even with sampling rate 0, the agent itself is enabled after AgentInfo succeeds.
     auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
     while (!agent->Enable() && std::chrono::steady_clock::now() < deadline) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -83,6 +83,9 @@ private:
         saved_env_vars_[env::SPAN_MAX_EVENT_DEPTH] = GetEnvVar(env::SPAN_MAX_EVENT_DEPTH);
         saved_env_vars_[env::SPAN_MAX_EVENT_SEQUENCE] = GetEnvVar(env::SPAN_MAX_EVENT_SEQUENCE);
         saved_env_vars_[env::SPAN_EVENT_CHUNK_SIZE] = GetEnvVar(env::SPAN_EVENT_CHUNK_SIZE);
+        saved_env_vars_[env::AGENT_INFO_REFRESH_INTERVAL_MS] = GetEnvVar(env::AGENT_INFO_REFRESH_INTERVAL_MS);
+        saved_env_vars_[env::AGENT_INFO_SEND_RETRY_INTERVAL_MS] = GetEnvVar(env::AGENT_INFO_SEND_RETRY_INTERVAL_MS);
+        saved_env_vars_[env::AGENT_INFO_MAX_TRY_PER_ATTEMPT] = GetEnvVar(env::AGENT_INFO_MAX_TRY_PER_ATTEMPT);
         saved_env_vars_[env::STAT_ENABLE] = GetEnvVar(env::STAT_ENABLE);
         saved_env_vars_[env::STAT_BATCH_COUNT] = GetEnvVar(env::STAT_BATCH_COUNT);
         saved_env_vars_[env::STAT_BATCH_INTERVAL] = GetEnvVar(env::STAT_BATCH_INTERVAL);
@@ -145,6 +148,11 @@ Span:
   MaxEventDepth: 32
   MaxEventSequence: 512
   EventChunkSize: 50
+
+AgentInfo:
+  RefreshIntervalMs: 60000
+  SendRetryIntervalMs: 25
+  MaxTryPerAttempt: 2
 
 Stat:
   Enable: true
@@ -254,6 +262,13 @@ TEST_F(ConfigTest, DefaultConfigurationTest) {
     EXPECT_EQ(config->span.max_event_depth, 64) << "Default max event depth should be 64";
     EXPECT_EQ(config->span.max_event_sequence, 5000) << "Default max event sequence should be 5000";
     EXPECT_EQ(config->span.event_chunk_size, 20) << "Default event chunk size should be 20";
+
+    EXPECT_EQ(config->agent_info.refresh_interval_ms, defaults::AGENT_INFO_REFRESH_INTERVAL_MS)
+        << "Default AgentInfo refresh interval should match Java daily refresh";
+    EXPECT_EQ(config->agent_info.send_retry_interval_ms, defaults::AGENT_INFO_SEND_RETRY_INTERVAL_MS)
+        << "Default AgentInfo retry interval should be 3000ms";
+    EXPECT_EQ(config->agent_info.max_try_per_attempt, defaults::AGENT_INFO_MAX_TRY_PER_ATTEMPT)
+        << "Default AgentInfo max try count should be 3";
     
     // Test stat defaults
     EXPECT_TRUE(config->stat.enable) << "Stat should be enabled by default";
@@ -339,6 +354,10 @@ TEST_F(ConfigTest, CompleteYamlConfigurationTest) {
     EXPECT_EQ(config->span.max_event_depth, 32) << "Max event depth should match YAML";
     EXPECT_EQ(config->span.max_event_sequence, 512) << "Max event sequence should match YAML";
     EXPECT_EQ(config->span.event_chunk_size, 50) << "Event chunk size should match YAML";
+
+    EXPECT_EQ(config->agent_info.refresh_interval_ms, 60000) << "AgentInfo refresh interval should match YAML";
+    EXPECT_EQ(config->agent_info.send_retry_interval_ms, 25) << "AgentInfo retry interval should match YAML";
+    EXPECT_EQ(config->agent_info.max_try_per_attempt, 2) << "AgentInfo max try count should match YAML";
     
     // Test stat configuration
     EXPECT_TRUE(config->stat.enable) << "Stat enable should match YAML";
@@ -448,6 +467,9 @@ TEST_F(ConfigTest, EnvironmentVariableConfigurationTest) {
     setenv(env::SQL_MAX_BIND_ARGS_SIZE, "4096", 1);
     setenv(env::SQL_ENABLE_SQL_STATS, "true", 1);
     setenv(env::HTTP_URL_STAT_ENABLE_TRIM_PATH, "false", 1);
+    setenv(env::AGENT_INFO_REFRESH_INTERVAL_MS, "120000", 1);
+    setenv(env::AGENT_INFO_SEND_RETRY_INTERVAL_MS, "50", 1);
+    setenv(env::AGENT_INFO_MAX_TRY_PER_ATTEMPT, "4", 1);
     
     auto config = make_config();
     
@@ -468,6 +490,10 @@ TEST_F(ConfigTest, EnvironmentVariableConfigurationTest) {
     
     // Test HTTP environment variable values
     EXPECT_FALSE(config->http.url_stat.enable_trim_path) << "URL stat enable trim path should match environment variable";
+
+    EXPECT_EQ(config->agent_info.refresh_interval_ms, 120000) << "AgentInfo refresh interval should match environment variable";
+    EXPECT_EQ(config->agent_info.send_retry_interval_ms, 50) << "AgentInfo retry interval should match environment variable";
+    EXPECT_EQ(config->agent_info.max_try_per_attempt, 4) << "AgentInfo max try count should match environment variable";
 }
 
 // Test environment variable override YAML

--- a/test/test_grpc_with_mocks.cpp
+++ b/test/test_grpc_with_mocks.cpp
@@ -16,7 +16,9 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <atomic>
 #include <chrono>
+#include <future>
 #include <thread>
 #include <memory>
 #include <string>
@@ -97,6 +99,36 @@ protected:
 
 private:
     bool ready_channel_{true};
+};
+
+class RetryingAgentInfoGrpcAgent : public GrpcAgent {
+public:
+    explicit RetryingAgentInfoGrpcAgent(std::shared_ptr<const Config> config)
+        : GrpcAgent(std::move(config)) {}
+
+    GrpcRequestStatus registerAgent() override {
+        const auto count = calls_.fetch_add(1) + 1;
+        if (count >= 2) {
+            if (success_promise_ != nullptr && !promise_set_.exchange(true)) {
+                success_promise_->set_value();
+            }
+            return SEND_OK;
+        }
+        return SEND_FAIL;
+    }
+
+    void setSuccessPromise(std::promise<void>* promise) {
+        success_promise_ = promise;
+    }
+
+    int calls() const {
+        return calls_.load();
+    }
+
+private:
+    std::atomic<int> calls_{0};
+    std::atomic<bool> promise_set_{false};
+    std::promise<void>* success_promise_{nullptr};
 };
 
 class TestableGrpcSpan : public GrpcSpan {
@@ -211,6 +243,26 @@ TEST_F(GrpcMockTest, GrpcAgentRegisterAgentFailureTest) {
     GrpcRequestStatus status = agent.registerAgent();
     
     EXPECT_EQ(status, SEND_FAIL) << "Agent registration should fail with mock stub error";
+}
+
+TEST_F(GrpcMockTest, GrpcAgentInfoRetriesUntilSuccess) {
+    auto cfg = mock_agent_service_->mutableConfig();
+    cfg->agent_info.refresh_interval_ms = 60 * 1000;
+    cfg->agent_info.send_retry_interval_ms = 10;
+    cfg->agent_info.max_try_per_attempt = 3;
+
+    RetryingAgentInfoGrpcAgent grpc_agent(cfg);
+    std::promise<void> success_promise;
+    auto success = success_promise.get_future();
+    grpc_agent.setSuccessPromise(&success_promise);
+    grpc_agent.setAgentService(mock_agent_service_.get());
+
+    grpc_agent.startAgentInfo();
+
+    EXPECT_EQ(success.wait_for(std::chrono::seconds(1)), std::future_status::ready)
+        << "GrpcAgent should retry AgentInfo after the configured interval";
+    grpc_agent.stopAgentInfo();
+    EXPECT_GE(grpc_agent.calls(), 2);
 }
 
 TEST_F(GrpcMockTest, GrpcAgentMetaDataEnqueueTest) {
@@ -1042,4 +1094,3 @@ TEST_F(GrpcMockTest, GrpcAgentMultipleRegisterTest) {
 }
 
 } // namespace pinpoint
-

--- a/test/test_tracer_c.cpp
+++ b/test/test_tracer_c.cpp
@@ -80,11 +80,8 @@ public:
         set_meta_stub(std::move(meta_stub));
     }
 
-    bool readyChannel() override { return ready_count_++ == 0; }
+    bool readyChannel() override { return false; }
     pinpoint::GrpcRequestStatus registerAgent() override { return pinpoint::SEND_OK; }
-
-private:
-    std::atomic<int> ready_count_{0};
 };
 
 class TestableGrpcSpan : public pinpoint::GrpcSpan {


### PR DESCRIPTION
## Summary

- Integrate Java-style AgentInfo scheduling into `GrpcAgent` without adding a separate sender class.
- Start AgentInfo sending independently from gRPC worker startup, with immediate send, retry, and 24-hour refresh behavior.
- Enable `AgentImpl` only after the first successful AgentInfo send.
- Add AgentInfo retry/refresh configuration and test coverage.

Closes #79.

## Behavior

- Initial AgentInfo send retries until it succeeds.
- Refresh attempts retry up to the configured max try count.
- Config reload triggers an explicit AgentInfo refresh request.
- AgentInfo scheduler stops during agent shutdown.

## Verification

- `bash -lc "source scripts/dev-shell.sh; cmake --build --preset debug-cached"`
- `ctest --test-dir build/debug-cached -R "test_grpc|test_grpc_with_mocks|test_agent_with_mocks|test_tracer_c" --output-on-failure`

Note: this worktree does not contain `scripts/dev-shell.sh`, so the shell prints `bash: scripts/dev-shell.sh: No such file or directory`; the CMake build still completed successfully.
