### PR TITLE
[#81] Add configurable gRPC channel options

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -10,6 +10,7 @@ This document is a consolidated reference for all configuration options availabl
 - [Agent Configuration](#agent-configuration)
 - [Logging Configuration](#logging-configuration)
 - [Collector Configuration](#collector-configuration)
+- [gRPC Transport Configuration](#grpc-transport-configuration)
 - [Stat Configuration](#stat-configuration)
 - [Sampling Configuration](#sampling-configuration)
 - [Span Configuration](#span-configuration)
@@ -128,6 +129,55 @@ int main() {
 | `Collector.GrpcAgentPort` | `PINPOINT_CPP_GRPC_AGENT_PORT` | int | `9991` | gRPC port for agent metadata. |
 | `Collector.GrpcSpanPort` | `PINPOINT_CPP_GRPC_SPAN_PORT` | int | `9993` | gRPC port for span data. |
 | `Collector.GrpcStatPort` | `PINPOINT_CPP_GRPC_STAT_PORT` | int | `9992` | gRPC port for statistics data. |
+
+---
+
+## gRPC Transport Configuration
+
+The C++ agent exposes Java-agent-style gRPC transport options under `Grpc`. Defaults preserve the previous C++ behavior: plaintext channels, 30s/60s keepalive, 4MiB message limits, 60s agent registration/span batch deadline, 5s metadata deadline, and no stat stream deadline.
+
+### TLS
+
+| YAML Key | Environment Variable | Type | Default | Notes |
+|---|---|---|---|---|
+| `Grpc.Ssl.TrustCertFilePath` | `PINPOINT_CPP_GRPC_SSL_TRUST_CERT_FILE_PATH` | string | `""` | PEM trust certificate path used by TLS credentials. |
+| `Grpc.Ssl.RootCertFilePath` | `PINPOINT_CPP_GRPC_SSL_ROOT_CERT_FILE_PATH` | string | `""` | Alias for gRPC root certificate path. `TrustCertFilePath` takes precedence when both are set. |
+
+### Per-channel Options
+
+Replace `<Channel>` with `Agent`, `Metadata`, `Span`, or `Stat` in YAML, and `CHANNEL` with `AGENT`, `METADATA`, `SPAN`, or `STAT` in env vars.
+
+| YAML Key | Environment Variable | Type | Default | Notes |
+|---|---|---|---|---|
+| `Grpc.<Channel>.SslEnable` | `PINPOINT_CPP_GRPC_<CHANNEL>_SSL_ENABLE` | bool | `false` | Enables TLS credentials for that channel. |
+| `Grpc.<Channel>.RequestTimeoutMs` | `PINPOINT_CPP_GRPC_<CHANNEL>_REQUEST_TIMEOUT_MS` | int | channel-specific | `0` disables the deadline. Defaults: Agent `60000`, Metadata `5000`, Span `60000`, Stat `0`. |
+| `Grpc.<Channel>.KeepAliveTimeMs` | `PINPOINT_CPP_GRPC_<CHANNEL>_KEEPALIVE_TIME_MS` | int | `30000` | Maps to `GRPC_ARG_KEEPALIVE_TIME_MS`. |
+| `Grpc.<Channel>.KeepAliveTimeoutMs` | `PINPOINT_CPP_GRPC_<CHANNEL>_KEEPALIVE_TIMEOUT_MS` | int | `60000` | Maps to `GRPC_ARG_KEEPALIVE_TIMEOUT_MS`. |
+| `Grpc.<Channel>.KeepAlivePermitWithoutCalls` | `PINPOINT_CPP_GRPC_<CHANNEL>_KEEPALIVE_PERMIT_WITHOUT_CALLS` | bool | `false` | Maps to `GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS`. |
+| `Grpc.<Channel>.MaxSendMessageSize` | `PINPOINT_CPP_GRPC_<CHANNEL>_MAX_SEND_MESSAGE_SIZE` | int | `4194304` | Maps to `GRPC_ARG_MAX_SEND_MESSAGE_LENGTH`. `-1` means unlimited. |
+| `Grpc.<Channel>.MaxReceiveMessageSize` | `PINPOINT_CPP_GRPC_<CHANNEL>_MAX_RECEIVE_MESSAGE_SIZE` | int | `4194304` | Maps to `GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH`. `-1` means unlimited. |
+| `Grpc.<Channel>.SenderQueueSize` | `PINPOINT_CPP_GRPC_<CHANNEL>_SENDER_QUEUE_SIZE` | int | `1000` | Applied to metadata queue. Span still uses `Span.QueueSize`; agent/stat have no separate C++ sender queue. |
+| `Grpc.<Channel>.ChannelExecutorQueueSize` | `PINPOINT_CPP_GRPC_<CHANNEL>_CHANNEL_EXECUTOR_QUEUE_SIZE` | int | `1000` | Parsed for Java config parity. The C++ gRPC API used here does not expose the same Netty executor queue. |
+
+Metadata now owns a separate C++ gRPC channel, so `Grpc.Metadata` SSL, keepalive, message-size, request-timeout, and sender-queue settings are applied independently from `Grpc.Agent`. Java-specific name resolver providers, custom interceptor injection, Netty channel type, channelz reporter wiring, retry/hedging service config, flow-control window, and write-buffer watermarks do not have a direct equivalent in the current C++ agent implementation.
+
+```yaml
+Grpc:
+  Ssl:
+    TrustCertFilePath: "/etc/pinpoint/collector-ca.pem"
+  Agent:
+    SslEnable: true
+    RequestTimeoutMs: 60000
+  Metadata:
+    RequestTimeoutMs: 5000
+    SenderQueueSize: 1000
+  Span:
+    SslEnable: true
+    MaxSendMessageSize: 4194304
+    MaxReceiveMessageSize: 4194304
+  Stat:
+    SslEnable: true
+```
 
 ---
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <sstream>
 #include <algorithm>
+#include <tuple>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
@@ -213,6 +214,39 @@ namespace pinpoint {
         return default_value;
     }
 
+    static void load_grpc_channel_yaml(const YAML::Node& yaml, std::string_view cname,
+                                       Config::GrpcChannelOptions& options) {
+        if (auto& channel = yaml[cname]) {
+            options.ssl_enable = get_boolean(channel, "SslEnable", options.ssl_enable);
+            options.request_timeout_ms = get_int(channel, "RequestTimeoutMs", options.request_timeout_ms);
+            options.keepalive_time_ms = get_int(channel, "KeepAliveTimeMs", options.keepalive_time_ms);
+            options.keepalive_timeout_ms = get_int(channel, "KeepAliveTimeoutMs", options.keepalive_timeout_ms);
+            options.keepalive_permit_without_calls =
+                get_boolean(channel, "KeepAlivePermitWithoutCalls", options.keepalive_permit_without_calls);
+            options.max_send_message_size = get_int(channel, "MaxSendMessageSize", options.max_send_message_size);
+            options.max_receive_message_size = get_int(channel, "MaxReceiveMessageSize", options.max_receive_message_size);
+            options.sender_queue_size = get_int(channel, "SenderQueueSize", options.sender_queue_size);
+            options.channel_executor_queue_size =
+                get_int(channel, "ChannelExecutorQueueSize", options.channel_executor_queue_size);
+        }
+    }
+
+    static void load_grpc_yaml(const YAML::Node& yaml, Config& config) {
+        if (auto& grpc = yaml["Grpc"]) {
+            if (auto& ssl = grpc["Ssl"]) {
+                config.grpc.ssl.trust_cert_file_path =
+                    get_string(ssl, "TrustCertFilePath", config.grpc.ssl.trust_cert_file_path);
+                config.grpc.ssl.root_cert_file_path =
+                    get_string(ssl, "RootCertFilePath", config.grpc.ssl.root_cert_file_path);
+            }
+
+            load_grpc_channel_yaml(grpc, "Agent", config.grpc.agent);
+            load_grpc_channel_yaml(grpc, "Metadata", config.grpc.metadata);
+            load_grpc_channel_yaml(grpc, "Span", config.grpc.span);
+            load_grpc_channel_yaml(grpc, "Stat", config.grpc.stat);
+        }
+    }
+
     static double get_double(const YAML::Node& yaml, std::string_view cname, double default_value) {
         if (yaml[cname]) {
             try {
@@ -309,6 +343,8 @@ namespace pinpoint {
             config.agent_info.max_try_per_attempt = get_int(agent_info, "MaxTryPerAttempt", defaults::AGENT_INFO_MAX_TRY_PER_ATTEMPT);
         }
 
+        load_grpc_yaml(yaml, config);
+
         if (yaml["IsContainer"]) {
             config.is_container = get_boolean(yaml, "IsContainer", false);
             is_container_set = true;
@@ -352,6 +388,47 @@ namespace pinpoint {
             LOG_WARN("Invalid double value '{}' for environment variable '{}'. Using default value: {}", 
                      env_value, env_name, default_value);
             return default_value;
+        }
+    }
+
+    static void load_env_grpc_channel(Config::GrpcChannelOptions& options,
+                                      const char* ssl_enable_env,
+                                      const char* request_timeout_env,
+                                      const char* keepalive_time_env,
+                                      const char* keepalive_timeout_env,
+                                      const char* keepalive_permit_env,
+                                      const char* max_send_env,
+                                      const char* max_receive_env,
+                                      const char* sender_queue_env,
+                                      const char* channel_executor_queue_env) {
+        if(const char* env_p = std::getenv(ssl_enable_env)) {
+            options.ssl_enable = safe_env_stob(ssl_enable_env, env_p, options.ssl_enable);
+        }
+        if(const char* env_p = std::getenv(request_timeout_env)) {
+            options.request_timeout_ms = safe_env_stoi(request_timeout_env, env_p, options.request_timeout_ms);
+        }
+        if(const char* env_p = std::getenv(keepalive_time_env)) {
+            options.keepalive_time_ms = safe_env_stoi(keepalive_time_env, env_p, options.keepalive_time_ms);
+        }
+        if(const char* env_p = std::getenv(keepalive_timeout_env)) {
+            options.keepalive_timeout_ms = safe_env_stoi(keepalive_timeout_env, env_p, options.keepalive_timeout_ms);
+        }
+        if(const char* env_p = std::getenv(keepalive_permit_env)) {
+            options.keepalive_permit_without_calls =
+                safe_env_stob(keepalive_permit_env, env_p, options.keepalive_permit_without_calls);
+        }
+        if(const char* env_p = std::getenv(max_send_env)) {
+            options.max_send_message_size = safe_env_stoi(max_send_env, env_p, options.max_send_message_size);
+        }
+        if(const char* env_p = std::getenv(max_receive_env)) {
+            options.max_receive_message_size = safe_env_stoi(max_receive_env, env_p, options.max_receive_message_size);
+        }
+        if(const char* env_p = std::getenv(sender_queue_env)) {
+            options.sender_queue_size = safe_env_stoi(sender_queue_env, env_p, options.sender_queue_size);
+        }
+        if(const char* env_p = std::getenv(channel_executor_queue_env)) {
+            options.channel_executor_queue_size =
+                safe_env_stoi(channel_executor_queue_env, env_p, options.channel_executor_queue_size);
         }
     }
 
@@ -454,6 +531,53 @@ namespace pinpoint {
         if(const char* env_p = std::getenv(env::AGENT_INFO_MAX_TRY_PER_ATTEMPT)) {
             config.agent_info.max_try_per_attempt = safe_env_stoi(env::AGENT_INFO_MAX_TRY_PER_ATTEMPT, env_p, defaults::AGENT_INFO_MAX_TRY_PER_ATTEMPT);
         }
+
+        if(const char* env_p = std::getenv(env::GRPC_SSL_TRUST_CERT_FILE_PATH)) {
+            config.grpc.ssl.trust_cert_file_path = std::string(env_p);
+        }
+        if(const char* env_p = std::getenv(env::GRPC_SSL_ROOT_CERT_FILE_PATH)) {
+            config.grpc.ssl.root_cert_file_path = std::string(env_p);
+        }
+        load_env_grpc_channel(config.grpc.agent,
+                              env::GRPC_AGENT_SSL_ENABLE,
+                              env::GRPC_AGENT_REQUEST_TIMEOUT_MS,
+                              env::GRPC_AGENT_KEEPALIVE_TIME_MS,
+                              env::GRPC_AGENT_KEEPALIVE_TIMEOUT_MS,
+                              env::GRPC_AGENT_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+                              env::GRPC_AGENT_MAX_SEND_MESSAGE_SIZE,
+                              env::GRPC_AGENT_MAX_RECEIVE_MESSAGE_SIZE,
+                              env::GRPC_AGENT_SENDER_QUEUE_SIZE,
+                              env::GRPC_AGENT_CHANNEL_EXECUTOR_QUEUE_SIZE);
+        load_env_grpc_channel(config.grpc.metadata,
+                              env::GRPC_METADATA_SSL_ENABLE,
+                              env::GRPC_METADATA_REQUEST_TIMEOUT_MS,
+                              env::GRPC_METADATA_KEEPALIVE_TIME_MS,
+                              env::GRPC_METADATA_KEEPALIVE_TIMEOUT_MS,
+                              env::GRPC_METADATA_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+                              env::GRPC_METADATA_MAX_SEND_MESSAGE_SIZE,
+                              env::GRPC_METADATA_MAX_RECEIVE_MESSAGE_SIZE,
+                              env::GRPC_METADATA_SENDER_QUEUE_SIZE,
+                              env::GRPC_METADATA_CHANNEL_EXECUTOR_QUEUE_SIZE);
+        load_env_grpc_channel(config.grpc.span,
+                              env::GRPC_SPAN_SSL_ENABLE,
+                              env::GRPC_SPAN_REQUEST_TIMEOUT_MS,
+                              env::GRPC_SPAN_KEEPALIVE_TIME_MS,
+                              env::GRPC_SPAN_KEEPALIVE_TIMEOUT_MS,
+                              env::GRPC_SPAN_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+                              env::GRPC_SPAN_MAX_SEND_MESSAGE_SIZE,
+                              env::GRPC_SPAN_MAX_RECEIVE_MESSAGE_SIZE,
+                              env::GRPC_SPAN_SENDER_QUEUE_SIZE,
+                              env::GRPC_SPAN_CHANNEL_EXECUTOR_QUEUE_SIZE);
+        load_env_grpc_channel(config.grpc.stat,
+                              env::GRPC_STAT_SSL_ENABLE,
+                              env::GRPC_STAT_REQUEST_TIMEOUT_MS,
+                              env::GRPC_STAT_KEEPALIVE_TIME_MS,
+                              env::GRPC_STAT_KEEPALIVE_TIMEOUT_MS,
+                              env::GRPC_STAT_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+                              env::GRPC_STAT_MAX_SEND_MESSAGE_SIZE,
+                              env::GRPC_STAT_MAX_RECEIVE_MESSAGE_SIZE,
+                              env::GRPC_STAT_SENDER_QUEUE_SIZE,
+                              env::GRPC_STAT_CHANNEL_EXECUTOR_QUEUE_SIZE);
 
         if(const char* env_p = std::getenv(env::IS_CONTAINER)) {
             config.is_container = safe_env_stob(env::IS_CONTAINER, env_p, false);
@@ -591,6 +715,8 @@ namespace pinpoint {
     constexpr int MAX_STAT_BATCH_COUNT = 100;
     constexpr int MIN_STAT_INTERVAL_MS = 1000;
     constexpr int MAX_STAT_INTERVAL_MS = 60000;
+    constexpr int MIN_GRPC_QUEUE_SIZE = 1;
+    constexpr int MAX_GRPC_QUEUE_SIZE = 65536;
 
     static int clamp_port(int port, int default_port) {
         if (port < MIN_PORT || port > MAX_PORT) {
@@ -598,6 +724,47 @@ namespace pinpoint {
             return default_port;
         }
         return port;
+    }
+
+    static void validate_grpc_channel(Config::GrpcChannelOptions& options, const char* name,
+                                      const Config::GrpcChannelOptions& defaults) {
+        if (options.request_timeout_ms < 0) {
+            LOG_WARN("{} grpc request timeout {}ms is invalid, using default: {}ms",
+                     name, options.request_timeout_ms, defaults.request_timeout_ms);
+            options.request_timeout_ms = defaults.request_timeout_ms;
+        }
+        if (options.keepalive_time_ms < 0) {
+            LOG_WARN("{} grpc keepalive time {}ms is invalid, using default: {}ms",
+                     name, options.keepalive_time_ms, defaults.keepalive_time_ms);
+            options.keepalive_time_ms = defaults.keepalive_time_ms;
+        }
+        if (options.keepalive_timeout_ms < 0) {
+            LOG_WARN("{} grpc keepalive timeout {}ms is invalid, using default: {}ms",
+                     name, options.keepalive_timeout_ms, defaults.keepalive_timeout_ms);
+            options.keepalive_timeout_ms = defaults.keepalive_timeout_ms;
+        }
+        if (options.max_send_message_size < UNLIMITED_SIZE) {
+            LOG_WARN("{} grpc max send message size {} is invalid, using default: {}",
+                     name, options.max_send_message_size, defaults.max_send_message_size);
+            options.max_send_message_size = defaults.max_send_message_size;
+        }
+        if (options.max_receive_message_size < UNLIMITED_SIZE) {
+            LOG_WARN("{} grpc max receive message size {} is invalid, using default: {}",
+                     name, options.max_receive_message_size, defaults.max_receive_message_size);
+            options.max_receive_message_size = defaults.max_receive_message_size;
+        }
+        if (options.sender_queue_size < MIN_GRPC_QUEUE_SIZE || options.sender_queue_size > MAX_GRPC_QUEUE_SIZE) {
+            LOG_WARN("{} grpc sender queue size {} is out of range ({}-{}), using default: {}",
+                     name, options.sender_queue_size, MIN_GRPC_QUEUE_SIZE, MAX_GRPC_QUEUE_SIZE, defaults.sender_queue_size);
+            options.sender_queue_size = defaults.sender_queue_size;
+        }
+        if (options.channel_executor_queue_size < MIN_GRPC_QUEUE_SIZE ||
+            options.channel_executor_queue_size > MAX_GRPC_QUEUE_SIZE) {
+            LOG_WARN("{} grpc channel executor queue size {} is out of range ({}-{}), using default: {}",
+                     name, options.channel_executor_queue_size, MIN_GRPC_QUEUE_SIZE, MAX_GRPC_QUEUE_SIZE,
+                     defaults.channel_executor_queue_size);
+            options.channel_executor_queue_size = defaults.channel_executor_queue_size;
+        }
     }
 
     std::shared_ptr<Config> make_config() {
@@ -744,6 +911,15 @@ namespace pinpoint {
             config->agent_info.max_try_per_attempt = defaults::AGENT_INFO_MAX_TRY_PER_ATTEMPT;
         }
 
+        validate_grpc_channel(config->grpc.agent, "agent",
+                              Config::GrpcChannelOptions(defaults::GRPC_AGENT_REQUEST_TIMEOUT_MS));
+        validate_grpc_channel(config->grpc.metadata, "metadata",
+                              Config::GrpcChannelOptions(defaults::GRPC_METADATA_REQUEST_TIMEOUT_MS));
+        validate_grpc_channel(config->grpc.span, "span",
+                              Config::GrpcChannelOptions(defaults::GRPC_SPAN_REQUEST_TIMEOUT_MS));
+        validate_grpc_channel(config->grpc.stat, "stat",
+                              Config::GrpcChannelOptions(defaults::GRPC_STAT_REQUEST_TIMEOUT_MS));
+
         if (!is_container_set) {
             config->is_container = is_container_env();
         }
@@ -777,6 +953,34 @@ namespace pinpoint {
         emitter << YAML::Key << "GrpcAgentPort" << YAML::Value << config.collector.agent_port;
         emitter << YAML::Key << "GrpcSpanPort" << YAML::Value << config.collector.span_port;
         emitter << YAML::Key << "GrpcStatPort" << YAML::Value << config.collector.stat_port;
+        emitter << YAML::EndMap;
+
+        auto emit_grpc_channel = [&emitter](const char* key, const Config::GrpcChannelOptions& options) {
+            emitter << YAML::Key << key;
+            emitter << YAML::BeginMap;
+            emitter << YAML::Key << "SslEnable" << YAML::Value << options.ssl_enable;
+            emitter << YAML::Key << "RequestTimeoutMs" << YAML::Value << options.request_timeout_ms;
+            emitter << YAML::Key << "KeepAliveTimeMs" << YAML::Value << options.keepalive_time_ms;
+            emitter << YAML::Key << "KeepAliveTimeoutMs" << YAML::Value << options.keepalive_timeout_ms;
+            emitter << YAML::Key << "KeepAlivePermitWithoutCalls" << YAML::Value << options.keepalive_permit_without_calls;
+            emitter << YAML::Key << "MaxSendMessageSize" << YAML::Value << options.max_send_message_size;
+            emitter << YAML::Key << "MaxReceiveMessageSize" << YAML::Value << options.max_receive_message_size;
+            emitter << YAML::Key << "SenderQueueSize" << YAML::Value << options.sender_queue_size;
+            emitter << YAML::Key << "ChannelExecutorQueueSize" << YAML::Value << options.channel_executor_queue_size;
+            emitter << YAML::EndMap;
+        };
+
+        emitter << YAML::Key << "Grpc";
+        emitter << YAML::BeginMap;
+        emitter << YAML::Key << "Ssl";
+        emitter << YAML::BeginMap;
+        emitter << YAML::Key << "TrustCertFilePath" << YAML::Value << config.grpc.ssl.trust_cert_file_path;
+        emitter << YAML::Key << "RootCertFilePath" << YAML::Value << config.grpc.ssl.root_cert_file_path;
+        emitter << YAML::EndMap;
+        emit_grpc_channel("Agent", config.grpc.agent);
+        emit_grpc_channel("Metadata", config.grpc.metadata);
+        emit_grpc_channel("Span", config.grpc.span);
+        emit_grpc_channel("Stat", config.grpc.stat);
         emitter << YAML::EndMap;
 
         emitter << YAML::Key << "Stat";
@@ -927,11 +1131,45 @@ namespace pinpoint {
         return true;
     }
 
+    static bool same_grpc_channel(const Config::GrpcChannelOptions& lhs,
+                                  const Config::GrpcChannelOptions& rhs) {
+        return std::tie(lhs.ssl_enable,
+                        lhs.request_timeout_ms,
+                        lhs.keepalive_time_ms,
+                        lhs.keepalive_timeout_ms,
+                        lhs.keepalive_permit_without_calls,
+                        lhs.max_send_message_size,
+                        lhs.max_receive_message_size,
+                        lhs.sender_queue_size,
+                        lhs.channel_executor_queue_size) ==
+               std::tie(rhs.ssl_enable,
+                        rhs.request_timeout_ms,
+                        rhs.keepalive_time_ms,
+                        rhs.keepalive_timeout_ms,
+                        rhs.keepalive_permit_without_calls,
+                        rhs.max_send_message_size,
+                        rhs.max_receive_message_size,
+                        rhs.sender_queue_size,
+                        rhs.channel_executor_queue_size);
+    }
+
+    static bool same_grpc_config(const Config& lhs, const Config& rhs) {
+        return std::tie(lhs.grpc.ssl.trust_cert_file_path,
+                        lhs.grpc.ssl.root_cert_file_path) ==
+               std::tie(rhs.grpc.ssl.trust_cert_file_path,
+                        rhs.grpc.ssl.root_cert_file_path) &&
+               same_grpc_channel(lhs.grpc.agent, rhs.grpc.agent) &&
+               same_grpc_channel(lhs.grpc.metadata, rhs.grpc.metadata) &&
+               same_grpc_channel(lhs.grpc.span, rhs.grpc.span) &&
+               same_grpc_channel(lhs.grpc.stat, rhs.grpc.stat);
+    }
+
     bool Config::isReloadable(const std::shared_ptr<const Config>& old) const {
         if (!old) return true;
         return std::tie(app_name_, app_type_, agent_id_, agent_name_,
                         collector.host, collector.agent_port, collector.span_port, collector.stat_port) ==
                std::tie(old->app_name_, old->app_type_, old->agent_id_, old->agent_name_,
-                        old->collector.host, old->collector.agent_port, old->collector.span_port, old->collector.stat_port);
+                        old->collector.host, old->collector.agent_port, old->collector.span_port, old->collector.stat_port) &&
+               same_grpc_config(*this, *old);
     }
 }

--- a/src/config.h
+++ b/src/config.h
@@ -44,6 +44,15 @@ namespace pinpoint {
         constexpr int AGENT_INFO_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
         constexpr int AGENT_INFO_SEND_RETRY_INTERVAL_MS = 3000;
         constexpr int AGENT_INFO_MAX_TRY_PER_ATTEMPT = 3;
+        constexpr int GRPC_KEEPALIVE_TIME_MS = 30 * 1000;
+        constexpr int GRPC_KEEPALIVE_TIMEOUT_MS = 60 * 1000;
+        constexpr int GRPC_MAX_MESSAGE_SIZE = 4 * 1024 * 1024;
+        constexpr int GRPC_AGENT_REQUEST_TIMEOUT_MS = 60 * 1000;
+        constexpr int GRPC_METADATA_REQUEST_TIMEOUT_MS = 5 * 1000;
+        constexpr int GRPC_SPAN_REQUEST_TIMEOUT_MS = 60 * 1000;
+        constexpr int GRPC_STAT_REQUEST_TIMEOUT_MS = 0;
+        constexpr int GRPC_SENDER_QUEUE_SIZE = 1000;
+        constexpr int GRPC_CHANNEL_EXECUTOR_QUEUE_SIZE = 1000;
         constexpr int HTTP_URL_STAT_LIMIT = 1024;
         constexpr int SQL_MAX_BIND_ARGS_SIZE = 1024;
         constexpr int LOG_MAX_FILE_SIZE_MB = 10;
@@ -89,6 +98,44 @@ namespace pinpoint {
         constexpr const char* AGENT_INFO_REFRESH_INTERVAL_MS = "PINPOINT_CPP_AGENT_INFO_REFRESH_INTERVAL_MS";
         constexpr const char* AGENT_INFO_SEND_RETRY_INTERVAL_MS = "PINPOINT_CPP_AGENT_INFO_SEND_RETRY_INTERVAL_MS";
         constexpr const char* AGENT_INFO_MAX_TRY_PER_ATTEMPT = "PINPOINT_CPP_AGENT_INFO_MAX_TRY_PER_ATTEMPT";
+        constexpr const char* GRPC_SSL_TRUST_CERT_FILE_PATH = "PINPOINT_CPP_GRPC_SSL_TRUST_CERT_FILE_PATH";
+        constexpr const char* GRPC_SSL_ROOT_CERT_FILE_PATH = "PINPOINT_CPP_GRPC_SSL_ROOT_CERT_FILE_PATH";
+        constexpr const char* GRPC_AGENT_SSL_ENABLE = "PINPOINT_CPP_GRPC_AGENT_SSL_ENABLE";
+        constexpr const char* GRPC_AGENT_REQUEST_TIMEOUT_MS = "PINPOINT_CPP_GRPC_AGENT_REQUEST_TIMEOUT_MS";
+        constexpr const char* GRPC_AGENT_KEEPALIVE_TIME_MS = "PINPOINT_CPP_GRPC_AGENT_KEEPALIVE_TIME_MS";
+        constexpr const char* GRPC_AGENT_KEEPALIVE_TIMEOUT_MS = "PINPOINT_CPP_GRPC_AGENT_KEEPALIVE_TIMEOUT_MS";
+        constexpr const char* GRPC_AGENT_KEEPALIVE_PERMIT_WITHOUT_CALLS = "PINPOINT_CPP_GRPC_AGENT_KEEPALIVE_PERMIT_WITHOUT_CALLS";
+        constexpr const char* GRPC_AGENT_MAX_SEND_MESSAGE_SIZE = "PINPOINT_CPP_GRPC_AGENT_MAX_SEND_MESSAGE_SIZE";
+        constexpr const char* GRPC_AGENT_MAX_RECEIVE_MESSAGE_SIZE = "PINPOINT_CPP_GRPC_AGENT_MAX_RECEIVE_MESSAGE_SIZE";
+        constexpr const char* GRPC_AGENT_SENDER_QUEUE_SIZE = "PINPOINT_CPP_GRPC_AGENT_SENDER_QUEUE_SIZE";
+        constexpr const char* GRPC_AGENT_CHANNEL_EXECUTOR_QUEUE_SIZE = "PINPOINT_CPP_GRPC_AGENT_CHANNEL_EXECUTOR_QUEUE_SIZE";
+        constexpr const char* GRPC_METADATA_SSL_ENABLE = "PINPOINT_CPP_GRPC_METADATA_SSL_ENABLE";
+        constexpr const char* GRPC_METADATA_REQUEST_TIMEOUT_MS = "PINPOINT_CPP_GRPC_METADATA_REQUEST_TIMEOUT_MS";
+        constexpr const char* GRPC_METADATA_KEEPALIVE_TIME_MS = "PINPOINT_CPP_GRPC_METADATA_KEEPALIVE_TIME_MS";
+        constexpr const char* GRPC_METADATA_KEEPALIVE_TIMEOUT_MS = "PINPOINT_CPP_GRPC_METADATA_KEEPALIVE_TIMEOUT_MS";
+        constexpr const char* GRPC_METADATA_KEEPALIVE_PERMIT_WITHOUT_CALLS = "PINPOINT_CPP_GRPC_METADATA_KEEPALIVE_PERMIT_WITHOUT_CALLS";
+        constexpr const char* GRPC_METADATA_MAX_SEND_MESSAGE_SIZE = "PINPOINT_CPP_GRPC_METADATA_MAX_SEND_MESSAGE_SIZE";
+        constexpr const char* GRPC_METADATA_MAX_RECEIVE_MESSAGE_SIZE = "PINPOINT_CPP_GRPC_METADATA_MAX_RECEIVE_MESSAGE_SIZE";
+        constexpr const char* GRPC_METADATA_SENDER_QUEUE_SIZE = "PINPOINT_CPP_GRPC_METADATA_SENDER_QUEUE_SIZE";
+        constexpr const char* GRPC_METADATA_CHANNEL_EXECUTOR_QUEUE_SIZE = "PINPOINT_CPP_GRPC_METADATA_CHANNEL_EXECUTOR_QUEUE_SIZE";
+        constexpr const char* GRPC_SPAN_SSL_ENABLE = "PINPOINT_CPP_GRPC_SPAN_SSL_ENABLE";
+        constexpr const char* GRPC_SPAN_REQUEST_TIMEOUT_MS = "PINPOINT_CPP_GRPC_SPAN_REQUEST_TIMEOUT_MS";
+        constexpr const char* GRPC_SPAN_KEEPALIVE_TIME_MS = "PINPOINT_CPP_GRPC_SPAN_KEEPALIVE_TIME_MS";
+        constexpr const char* GRPC_SPAN_KEEPALIVE_TIMEOUT_MS = "PINPOINT_CPP_GRPC_SPAN_KEEPALIVE_TIMEOUT_MS";
+        constexpr const char* GRPC_SPAN_KEEPALIVE_PERMIT_WITHOUT_CALLS = "PINPOINT_CPP_GRPC_SPAN_KEEPALIVE_PERMIT_WITHOUT_CALLS";
+        constexpr const char* GRPC_SPAN_MAX_SEND_MESSAGE_SIZE = "PINPOINT_CPP_GRPC_SPAN_MAX_SEND_MESSAGE_SIZE";
+        constexpr const char* GRPC_SPAN_MAX_RECEIVE_MESSAGE_SIZE = "PINPOINT_CPP_GRPC_SPAN_MAX_RECEIVE_MESSAGE_SIZE";
+        constexpr const char* GRPC_SPAN_SENDER_QUEUE_SIZE = "PINPOINT_CPP_GRPC_SPAN_SENDER_QUEUE_SIZE";
+        constexpr const char* GRPC_SPAN_CHANNEL_EXECUTOR_QUEUE_SIZE = "PINPOINT_CPP_GRPC_SPAN_CHANNEL_EXECUTOR_QUEUE_SIZE";
+        constexpr const char* GRPC_STAT_SSL_ENABLE = "PINPOINT_CPP_GRPC_STAT_SSL_ENABLE";
+        constexpr const char* GRPC_STAT_REQUEST_TIMEOUT_MS = "PINPOINT_CPP_GRPC_STAT_REQUEST_TIMEOUT_MS";
+        constexpr const char* GRPC_STAT_KEEPALIVE_TIME_MS = "PINPOINT_CPP_GRPC_STAT_KEEPALIVE_TIME_MS";
+        constexpr const char* GRPC_STAT_KEEPALIVE_TIMEOUT_MS = "PINPOINT_CPP_GRPC_STAT_KEEPALIVE_TIMEOUT_MS";
+        constexpr const char* GRPC_STAT_KEEPALIVE_PERMIT_WITHOUT_CALLS = "PINPOINT_CPP_GRPC_STAT_KEEPALIVE_PERMIT_WITHOUT_CALLS";
+        constexpr const char* GRPC_STAT_MAX_SEND_MESSAGE_SIZE = "PINPOINT_CPP_GRPC_STAT_MAX_SEND_MESSAGE_SIZE";
+        constexpr const char* GRPC_STAT_MAX_RECEIVE_MESSAGE_SIZE = "PINPOINT_CPP_GRPC_STAT_MAX_RECEIVE_MESSAGE_SIZE";
+        constexpr const char* GRPC_STAT_SENDER_QUEUE_SIZE = "PINPOINT_CPP_GRPC_STAT_SENDER_QUEUE_SIZE";
+        constexpr const char* GRPC_STAT_CHANNEL_EXECUTOR_QUEUE_SIZE = "PINPOINT_CPP_GRPC_STAT_CHANNEL_EXECUTOR_QUEUE_SIZE";
         constexpr const char* IS_CONTAINER = "PINPOINT_CPP_IS_CONTAINER";
         constexpr const char* HTTP_COLLECT_URL_STAT = "PINPOINT_CPP_HTTP_COLLECT_URL_STAT";
         constexpr const char* HTTP_URL_STAT_LIMIT = "PINPOINT_CPP_HTTP_URL_STAT_LIMIT";
@@ -166,6 +213,34 @@ namespace pinpoint {
                 int max_concurrent_requests = defaults::SPAN_BATCH_MAX_CONCURRENT_REQUESTS;
             } batch;
         } span;
+
+        struct GrpcSslOptions {
+            std::string trust_cert_file_path;
+            std::string root_cert_file_path;
+        };
+
+        struct GrpcChannelOptions {
+            explicit GrpcChannelOptions(int request_timeout = defaults::GRPC_STAT_REQUEST_TIMEOUT_MS)
+                : request_timeout_ms(request_timeout) {}
+
+            bool ssl_enable = false;
+            int request_timeout_ms;
+            int keepalive_time_ms = defaults::GRPC_KEEPALIVE_TIME_MS;
+            int keepalive_timeout_ms = defaults::GRPC_KEEPALIVE_TIMEOUT_MS;
+            bool keepalive_permit_without_calls = false;
+            int max_send_message_size = defaults::GRPC_MAX_MESSAGE_SIZE;
+            int max_receive_message_size = defaults::GRPC_MAX_MESSAGE_SIZE;
+            int sender_queue_size = defaults::GRPC_SENDER_QUEUE_SIZE;
+            int channel_executor_queue_size = defaults::GRPC_CHANNEL_EXECUTOR_QUEUE_SIZE;
+        };
+
+        struct {
+            GrpcSslOptions ssl;
+            GrpcChannelOptions agent{defaults::GRPC_AGENT_REQUEST_TIMEOUT_MS};
+            GrpcChannelOptions metadata{defaults::GRPC_METADATA_REQUEST_TIMEOUT_MS};
+            GrpcChannelOptions span{defaults::GRPC_SPAN_REQUEST_TIMEOUT_MS};
+            GrpcChannelOptions stat{defaults::GRPC_STAT_REQUEST_TIMEOUT_MS};
+        } grpc;
 
         struct {
             int refresh_interval_ms = defaults::AGENT_INFO_REFRESH_INTERVAL_MS;

--- a/src/grpc.cpp
+++ b/src/grpc.cpp
@@ -15,8 +15,11 @@
  */
 
 #include <cassert>
+#include <fstream>
 #include <limits>
 #include <memory>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 #include <unistd.h>
 #include <grpcpp/client_context.h>
@@ -29,13 +32,6 @@
 #include "grpc.h"
 
 namespace pinpoint {
-
-    namespace {
-        // gRPC channel configuration constants
-        constexpr int KEEPALIVE_TIME_MS = 30 * 1000;        // 30 seconds
-        constexpr int KEEPALIVE_TIMEOUT_MS = 60 * 1000;     // 60 seconds
-        constexpr int MAX_MESSAGE_LENGTH = 4 * 1024 * 1024; // 4 MB
-    }
 
     static v1::PTransactionId* build_transaction_id(TraceId& tid, google::protobuf::Arena* arena) {
         auto& [agent_id, start_time, sequence] = tid;
@@ -368,32 +364,121 @@ namespace pinpoint {
         return uri_stat;
     }
 
-    GrpcClient::GrpcClient(ClientType client_type, std::shared_ptr<const Config> config)
-        : config_{std::move(config)} {
-        auto addr = absl::StrCat(config_->collector.host, ":");
-
-        if (client_type == AGENT) {
-            addr = absl::StrCat(addr, config_->collector.agent_port);
-            client_name_ = "agent";
-        } else if (client_type == METADATA) {
-            addr = absl::StrCat(addr, config_->collector.agent_port);
-            client_name_ = "metadata";
-        } else if (client_type == SPAN) {
-            addr = absl::StrCat(addr, config_->collector.span_port);
-            client_name_ = "span";
-        } else {
-            addr = absl::StrCat(addr, config_->collector.stat_port);
-            client_name_ = "stats";
+    namespace {
+        const Config::GrpcChannelOptions& grpc_channel_options(const Config& config, ClientType client_type) {
+            switch (client_type) {
+                case AGENT:
+                    return config.grpc.agent;
+                case METADATA:
+                    return config.grpc.metadata;
+                case SPAN:
+                    return config.grpc.span;
+                case STATS:
+                    return config.grpc.stat;
+            }
+            return config.grpc.agent;
         }
 
-        grpc::ChannelArguments channel_args;
+        int grpc_collector_port(const Config& config, ClientType client_type) {
+            switch (client_type) {
+                case AGENT:
+                case METADATA:
+                    return config.collector.agent_port;
+                case SPAN:
+                    return config.collector.span_port;
+                case STATS:
+                    return config.collector.stat_port;
+            }
+            return config.collector.agent_port;
+        }
 
-        channel_args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, KEEPALIVE_TIME_MS);
-        channel_args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, KEEPALIVE_TIMEOUT_MS);
-        channel_args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 0);
-        channel_args.SetInt(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH, MAX_MESSAGE_LENGTH);
+        std::string grpc_client_name(ClientType client_type) {
+            switch (client_type) {
+                case AGENT:
+                    return "agent";
+                case METADATA:
+                    return "metadata";
+                case SPAN:
+                    return "span";
+                case STATS:
+                    return "stats";
+            }
+            return "agent";
+        }
 
-        channel_ = grpc::CreateCustomChannel(addr, grpc::InsecureChannelCredentials(), channel_args);
+        std::string read_file(std::string_view path) {
+            std::ifstream file(std::string(path), std::ios::binary);
+            if (!file.is_open()) {
+                throw std::runtime_error(absl::StrCat("failed to open gRPC TLS certificate file: ", path));
+            }
+
+            std::ostringstream buffer;
+            buffer << file.rdbuf();
+            return buffer.str();
+        }
+
+        std::shared_ptr<grpc::ChannelCredentials> make_channel_credentials(
+                const Config::GrpcSslOptions& ssl,
+                const Config::GrpcChannelOptions& channel_options,
+                std::string_view client_name) {
+            if (!channel_options.ssl_enable) {
+                return grpc::InsecureChannelCredentials();
+            }
+
+            grpc::SslCredentialsOptions ssl_options;
+            const auto& cert_path = !ssl.trust_cert_file_path.empty()
+                ? ssl.trust_cert_file_path
+                : ssl.root_cert_file_path;
+            if (!cert_path.empty()) {
+                ssl_options.pem_root_certs = read_file(cert_path);
+            }
+
+            LOG_INFO("create {} grpc TLS channel credentials: trustCertFilePath='{}', rootCertFilePath='{}'",
+                     client_name, ssl.trust_cert_file_path, ssl.root_cert_file_path);
+            return grpc::SslCredentials(ssl_options);
+        }
+
+        grpc::ChannelArguments make_channel_arguments(const Config::GrpcChannelOptions& options) {
+            grpc::ChannelArguments channel_args;
+
+            channel_args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, options.keepalive_time_ms);
+            channel_args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, options.keepalive_timeout_ms);
+            channel_args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+                                options.keepalive_permit_without_calls ? 1 : 0);
+            channel_args.SetInt(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH, options.max_send_message_size);
+            channel_args.SetInt(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, options.max_receive_message_size);
+
+            return channel_args;
+        }
+
+        std::shared_ptr<grpc::Channel> build_channel(const Config& config, ClientType client_type) {
+            const auto& options = grpc_channel_options(config, client_type);
+            const auto client_name = grpc_client_name(client_type);
+            const auto addr = absl::StrCat(config.collector.host, ":", grpc_collector_port(config, client_type));
+            auto credentials = make_channel_credentials(config.grpc.ssl, options, client_name);
+            auto channel_args = make_channel_arguments(options);
+
+            LOG_INFO("create {} grpc channel: addr={}, ssl={}, keepaliveTimeMs={}, keepaliveTimeoutMs={}, "
+                     "maxSendMessageSize={}, maxReceiveMessageSize={}",
+                     client_name, addr, options.ssl_enable, options.keepalive_time_ms,
+                     options.keepalive_timeout_ms, options.max_send_message_size,
+                     options.max_receive_message_size);
+            return grpc::CreateCustomChannel(addr, credentials, channel_args);
+        }
+
+        static void set_deadline(grpc::ClientContext& ctx, const int timeout_ms) {
+            if (timeout_ms <= 0) {
+                return;
+            }
+            auto deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(timeout_ms);
+            ctx.set_deadline(deadline);
+        }
+    }
+
+    GrpcClient::GrpcClient(ClientType client_type, std::shared_ptr<const Config> config)
+        : config_{std::move(config)}, client_type_(client_type) {
+        client_name_ = grpc_client_name(client_type_);
+        channel_ = build_channel(*config_, client_type_);
     }
 
     void GrpcClient::setAgentService(AgentService* agent) {
@@ -466,16 +551,8 @@ namespace pinpoint {
         return true;
     }
 
-    constexpr auto REGISTER_TIMEOUT = std::chrono::milliseconds(defaults::AGENT_INFO_SEND_RETRY_INTERVAL_MS);
-    constexpr auto META_TIMEOUT = std::chrono::seconds(5);
     constexpr int METADATA_RETRY_MAX_ATTEMPTS = 3;
     constexpr auto METADATA_RETRY_DELAY = std::chrono::milliseconds(1000);
-
-    template<typename Rep, typename Period>
-    static void set_deadline(grpc::ClientContext& ctx, const std::chrono::duration<Rep, Period> timeout) {
-        auto deadline = std::chrono::system_clock::now() + timeout;
-        ctx.set_deadline(deadline);
-    }
 
     //GrpcMetadata
 
@@ -490,7 +567,7 @@ namespace pinpoint {
         std::unique_lock<std::mutex> lock(channel_mutex_);
 
         build_grpc_context(&ctx, 0);
-        set_deadline(ctx, META_TIMEOUT);
+        set_deadline(ctx, config_->grpc.metadata.request_timeout_ms);
 
         const grpc::Status status = stub_method(&ctx, request, &reply);
 
@@ -645,11 +722,11 @@ namespace pinpoint {
 
         std::unique_lock<std::mutex> lock(meta_queue_mutex_);
 
-        const auto& config = config_;
-        if (meta_queue_.size() + retry_queue_.size() < config->span.queue_size) {
+        const auto max_queue_size = static_cast<size_t>(config_->grpc.metadata.sender_queue_size);
+        if (meta_queue_.size() + retry_queue_.size() < max_queue_size) {
             meta_queue_.push_back(PendingMeta{std::move(meta), 0, {}, meta_sequence_++});
         } else {
-            LOG_DEBUG("drop metadata: overflow max queue size {}", config->span.queue_size);
+            LOG_DEBUG("drop metadata: overflow max queue size {}", max_queue_size);
         }
 
         meta_queue_cv_.notify_one();
@@ -771,7 +848,7 @@ namespace pinpoint {
         auto* agent_info = google::protobuf::Arena::Create<v1::PAgentInfo>(&arena);
         build_agent_info(agent_info, &arena);
 
-        set_deadline(ctx, REGISTER_TIMEOUT);
+        set_deadline(ctx, config_->grpc.agent.request_timeout_ms);
         const grpc::Status status = agent_stub_->RequestAgentInfo(&ctx, *agent_info, &reply);
 
         if (status.ok()) {
@@ -1007,7 +1084,6 @@ namespace pinpoint {
     //GrpcSpan
 
     namespace {
-        constexpr auto SPAN_BATCH_TIMEOUT = std::chrono::seconds(60);
         constexpr auto SHUTDOWN_AWAIT_TIMEOUT = std::chrono::seconds(3);
 
         // Heap-resident state for a single async SendSpanBatch call. Lives as
@@ -1144,7 +1220,7 @@ namespace pinpoint {
         }
 
         build_grpc_context(&pending->ctx, 0);
-        set_deadline(pending->ctx, SPAN_BATCH_TIMEOUT);
+        set_deadline(pending->ctx, config_->grpc.span.request_timeout_ms);
 
         const int batch_count = pending->request->span_size();
         LOG_DEBUG("SendSpanBatch sending: batchSize={} concurrentRequests={}/{}",
@@ -1246,6 +1322,7 @@ namespace pinpoint {
 
         stream_context_ = std::make_unique<grpc::ClientContext>();
         build_grpc_context(stream_context_.get(), 0);
+        set_deadline(*stream_context_, config_->grpc.stat.request_timeout_ms);
         stats_stub_->async()->SendAgentStat(stream_context_.get(), &reply_, this);
 
         AddHold();

--- a/src/grpc.h
+++ b/src/grpc.h
@@ -90,6 +90,7 @@ namespace pinpoint {
         std::shared_ptr<grpc::Channel> channel_{};
         std::mutex channel_mutex_{};
         std::string client_name_{};
+        ClientType client_type_;
 
         std::unique_ptr<grpc::ClientContext> stream_context_{};
         std::mutex stream_mutex_{};

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -58,6 +58,49 @@ private:
         saved_env_vars_[env::GRPC_AGENT_PORT] = GetEnvVar(env::GRPC_AGENT_PORT);
         saved_env_vars_[env::GRPC_SPAN_PORT] = GetEnvVar(env::GRPC_SPAN_PORT);
         saved_env_vars_[env::GRPC_STAT_PORT] = GetEnvVar(env::GRPC_STAT_PORT);
+        const std::vector<const char*> grpc_env_vars = {
+            env::GRPC_SSL_TRUST_CERT_FILE_PATH,
+            env::GRPC_SSL_ROOT_CERT_FILE_PATH,
+            env::GRPC_AGENT_SSL_ENABLE,
+            env::GRPC_AGENT_REQUEST_TIMEOUT_MS,
+            env::GRPC_AGENT_KEEPALIVE_TIME_MS,
+            env::GRPC_AGENT_KEEPALIVE_TIMEOUT_MS,
+            env::GRPC_AGENT_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+            env::GRPC_AGENT_MAX_SEND_MESSAGE_SIZE,
+            env::GRPC_AGENT_MAX_RECEIVE_MESSAGE_SIZE,
+            env::GRPC_AGENT_SENDER_QUEUE_SIZE,
+            env::GRPC_AGENT_CHANNEL_EXECUTOR_QUEUE_SIZE,
+            env::GRPC_METADATA_SSL_ENABLE,
+            env::GRPC_METADATA_REQUEST_TIMEOUT_MS,
+            env::GRPC_METADATA_KEEPALIVE_TIME_MS,
+            env::GRPC_METADATA_KEEPALIVE_TIMEOUT_MS,
+            env::GRPC_METADATA_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+            env::GRPC_METADATA_MAX_SEND_MESSAGE_SIZE,
+            env::GRPC_METADATA_MAX_RECEIVE_MESSAGE_SIZE,
+            env::GRPC_METADATA_SENDER_QUEUE_SIZE,
+            env::GRPC_METADATA_CHANNEL_EXECUTOR_QUEUE_SIZE,
+            env::GRPC_SPAN_SSL_ENABLE,
+            env::GRPC_SPAN_REQUEST_TIMEOUT_MS,
+            env::GRPC_SPAN_KEEPALIVE_TIME_MS,
+            env::GRPC_SPAN_KEEPALIVE_TIMEOUT_MS,
+            env::GRPC_SPAN_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+            env::GRPC_SPAN_MAX_SEND_MESSAGE_SIZE,
+            env::GRPC_SPAN_MAX_RECEIVE_MESSAGE_SIZE,
+            env::GRPC_SPAN_SENDER_QUEUE_SIZE,
+            env::GRPC_SPAN_CHANNEL_EXECUTOR_QUEUE_SIZE,
+            env::GRPC_STAT_SSL_ENABLE,
+            env::GRPC_STAT_REQUEST_TIMEOUT_MS,
+            env::GRPC_STAT_KEEPALIVE_TIME_MS,
+            env::GRPC_STAT_KEEPALIVE_TIMEOUT_MS,
+            env::GRPC_STAT_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+            env::GRPC_STAT_MAX_SEND_MESSAGE_SIZE,
+            env::GRPC_STAT_MAX_RECEIVE_MESSAGE_SIZE,
+            env::GRPC_STAT_SENDER_QUEUE_SIZE,
+            env::GRPC_STAT_CHANNEL_EXECUTOR_QUEUE_SIZE,
+        };
+        for (const char* name : grpc_env_vars) {
+            saved_env_vars_[name] = GetEnvVar(name);
+        }
         saved_env_vars_[env::SAMPLING_TYPE] = GetEnvVar(env::SAMPLING_TYPE);
         saved_env_vars_[env::SAMPLING_PERCENT_RATE] = GetEnvVar(env::SAMPLING_PERCENT_RATE);
         saved_env_vars_[env::IS_CONTAINER] = GetEnvVar(env::IS_CONTAINER);
@@ -135,6 +178,33 @@ Collector:
   GrpcAgentPort: 9000
   GrpcSpanPort: 9001
   GrpcStatPort: 9002
+
+Grpc:
+  Ssl:
+    TrustCertFilePath: "/tmp/trust.pem"
+    RootCertFilePath: "/tmp/root.pem"
+  Agent:
+    SslEnable: true
+    RequestTimeoutMs: 61000
+    KeepAliveTimeMs: 31000
+    KeepAliveTimeoutMs: 62000
+    KeepAlivePermitWithoutCalls: true
+    MaxSendMessageSize: 5242880
+    MaxReceiveMessageSize: 6291456
+    SenderQueueSize: 1100
+    ChannelExecutorQueueSize: 1200
+  Metadata:
+    SslEnable: true
+    RequestTimeoutMs: 7000
+    SenderQueueSize: 1300
+  Span:
+    SslEnable: true
+    RequestTimeoutMs: 62000
+    MaxSendMessageSize: 7340032
+    MaxReceiveMessageSize: 8388608
+  Stat:
+    SslEnable: false
+    RequestTimeoutMs: 0
 
 Sampling:
   Type: "PERCENT"
@@ -249,6 +319,20 @@ TEST_F(ConfigTest, DefaultConfigurationTest) {
     EXPECT_EQ(config->collector.agent_port, 9991) << "Default agent port should be 9991";
     EXPECT_EQ(config->collector.span_port, 9993) << "Default span port should be 9993";
     EXPECT_EQ(config->collector.stat_port, 9992) << "Default stat port should be 9992";
+
+    // Test gRPC channel defaults
+    EXPECT_FALSE(config->grpc.agent.ssl_enable) << "Agent gRPC SSL should be disabled by default";
+    EXPECT_FALSE(config->grpc.metadata.ssl_enable) << "Metadata gRPC SSL should be disabled by default";
+    EXPECT_FALSE(config->grpc.span.ssl_enable) << "Span gRPC SSL should be disabled by default";
+    EXPECT_FALSE(config->grpc.stat.ssl_enable) << "Stat gRPC SSL should be disabled by default";
+    EXPECT_EQ(config->grpc.agent.request_timeout_ms, 60000) << "Agent request timeout should preserve current behavior";
+    EXPECT_EQ(config->grpc.metadata.request_timeout_ms, 5000) << "Metadata request timeout should preserve current behavior";
+    EXPECT_EQ(config->grpc.span.request_timeout_ms, 60000) << "Span request timeout should preserve current behavior";
+    EXPECT_EQ(config->grpc.stat.request_timeout_ms, 0) << "Stat stream should have no deadline by default";
+    EXPECT_EQ(config->grpc.agent.keepalive_time_ms, 30000) << "Default keepalive time should be 30s";
+    EXPECT_EQ(config->grpc.agent.keepalive_timeout_ms, 60000) << "Default keepalive timeout should be 60s";
+    EXPECT_EQ(config->grpc.agent.max_send_message_size, 4 * 1024 * 1024) << "Default max send size should be 4MiB";
+    EXPECT_EQ(config->grpc.agent.max_receive_message_size, 4 * 1024 * 1024) << "Default max receive size should be 4MiB";
     
     // Test sampling defaults
     EXPECT_EQ(config->sampling.type, "COUNTER") << "Default sampling type should be COUNTER";
@@ -341,6 +425,28 @@ TEST_F(ConfigTest, CompleteYamlConfigurationTest) {
     EXPECT_EQ(config->collector.agent_port, 9000) << "Agent port should match YAML";
     EXPECT_EQ(config->collector.span_port, 9001) << "Span port should match YAML";
     EXPECT_EQ(config->collector.stat_port, 9002) << "Stat port should match YAML";
+
+    // Test gRPC channel configuration
+    EXPECT_EQ(config->grpc.ssl.trust_cert_file_path, "/tmp/trust.pem") << "Trust cert path should match YAML";
+    EXPECT_EQ(config->grpc.ssl.root_cert_file_path, "/tmp/root.pem") << "Root cert path should match YAML";
+    EXPECT_TRUE(config->grpc.agent.ssl_enable) << "Agent SSL enable should match YAML";
+    EXPECT_EQ(config->grpc.agent.request_timeout_ms, 61000) << "Agent request timeout should match YAML";
+    EXPECT_EQ(config->grpc.agent.keepalive_time_ms, 31000) << "Agent keepalive time should match YAML";
+    EXPECT_EQ(config->grpc.agent.keepalive_timeout_ms, 62000) << "Agent keepalive timeout should match YAML";
+    EXPECT_TRUE(config->grpc.agent.keepalive_permit_without_calls) << "Agent keepalive permit should match YAML";
+    EXPECT_EQ(config->grpc.agent.max_send_message_size, 5242880) << "Agent max send size should match YAML";
+    EXPECT_EQ(config->grpc.agent.max_receive_message_size, 6291456) << "Agent max receive size should match YAML";
+    EXPECT_EQ(config->grpc.agent.sender_queue_size, 1100) << "Agent sender queue size should match YAML";
+    EXPECT_EQ(config->grpc.agent.channel_executor_queue_size, 1200) << "Agent channel queue size should match YAML";
+    EXPECT_TRUE(config->grpc.metadata.ssl_enable) << "Metadata SSL enable should match YAML";
+    EXPECT_EQ(config->grpc.metadata.request_timeout_ms, 7000) << "Metadata request timeout should match YAML";
+    EXPECT_EQ(config->grpc.metadata.sender_queue_size, 1300) << "Metadata sender queue size should match YAML";
+    EXPECT_TRUE(config->grpc.span.ssl_enable) << "Span SSL enable should match YAML";
+    EXPECT_EQ(config->grpc.span.request_timeout_ms, 62000) << "Span request timeout should match YAML";
+    EXPECT_EQ(config->grpc.span.max_send_message_size, 7340032) << "Span max send size should match YAML";
+    EXPECT_EQ(config->grpc.span.max_receive_message_size, 8388608) << "Span max receive size should match YAML";
+    EXPECT_FALSE(config->grpc.stat.ssl_enable) << "Stat SSL enable should match YAML";
+    EXPECT_EQ(config->grpc.stat.request_timeout_ms, 0) << "Stat request timeout should match YAML";
     
     // Test sampling configuration
     EXPECT_EQ(config->sampling.type, "PERCENT") << "Sampling type should match YAML";
@@ -470,6 +576,14 @@ TEST_F(ConfigTest, EnvironmentVariableConfigurationTest) {
     setenv(env::AGENT_INFO_REFRESH_INTERVAL_MS, "120000", 1);
     setenv(env::AGENT_INFO_SEND_RETRY_INTERVAL_MS, "50", 1);
     setenv(env::AGENT_INFO_MAX_TRY_PER_ATTEMPT, "4", 1);
+    setenv(env::GRPC_SSL_TRUST_CERT_FILE_PATH, "/env/trust.pem", 1);
+    setenv(env::GRPC_AGENT_SSL_ENABLE, "true", 1);
+    setenv(env::GRPC_AGENT_REQUEST_TIMEOUT_MS, "11111", 1);
+    setenv(env::GRPC_AGENT_KEEPALIVE_TIME_MS, "22222", 1);
+    setenv(env::GRPC_AGENT_MAX_SEND_MESSAGE_SIZE, "33333", 1);
+    setenv(env::GRPC_METADATA_SENDER_QUEUE_SIZE, "4444", 1);
+    setenv(env::GRPC_SPAN_MAX_RECEIVE_MESSAGE_SIZE, "55555", 1);
+    setenv(env::GRPC_STAT_REQUEST_TIMEOUT_MS, "66666", 1);
     
     auto config = make_config();
     
@@ -494,6 +608,16 @@ TEST_F(ConfigTest, EnvironmentVariableConfigurationTest) {
     EXPECT_EQ(config->agent_info.refresh_interval_ms, 120000) << "AgentInfo refresh interval should match environment variable";
     EXPECT_EQ(config->agent_info.send_retry_interval_ms, 50) << "AgentInfo retry interval should match environment variable";
     EXPECT_EQ(config->agent_info.max_try_per_attempt, 4) << "AgentInfo max try count should match environment variable";
+
+    // Test gRPC environment variable values
+    EXPECT_EQ(config->grpc.ssl.trust_cert_file_path, "/env/trust.pem") << "Trust cert path should match environment variable";
+    EXPECT_TRUE(config->grpc.agent.ssl_enable) << "Agent SSL enable should match environment variable";
+    EXPECT_EQ(config->grpc.agent.request_timeout_ms, 11111) << "Agent request timeout should match environment variable";
+    EXPECT_EQ(config->grpc.agent.keepalive_time_ms, 22222) << "Agent keepalive time should match environment variable";
+    EXPECT_EQ(config->grpc.agent.max_send_message_size, 33333) << "Agent max send size should match environment variable";
+    EXPECT_EQ(config->grpc.metadata.sender_queue_size, 4444) << "Metadata sender queue should match environment variable";
+    EXPECT_EQ(config->grpc.span.max_receive_message_size, 55555) << "Span max receive size should match environment variable";
+    EXPECT_EQ(config->grpc.stat.request_timeout_ms, 66666) << "Stat request timeout should match environment variable";
 }
 
 // Test environment variable override YAML
@@ -1525,6 +1649,19 @@ TEST_F(ConfigTest, IsReloadableReturnsFalseWhenPortChangesTest) {
 
     EXPECT_FALSE(new_config.isReloadable(old_config))
         << "Should not be reloadable when agent port changes";
+}
+
+// Test isReloadable() returns false when gRPC channel options change
+TEST_F(ConfigTest, IsReloadableReturnsFalseWhenGrpcChannelOptionsChangeTest) {
+    auto old_config = std::make_shared<Config>();
+    old_config->app_name_ = "MyApp";
+    old_config->collector.host = "localhost";
+
+    Config new_config = *old_config;
+    new_config.grpc.span.ssl_enable = true;
+
+    EXPECT_FALSE(new_config.isReloadable(old_config))
+        << "Should not be reloadable when gRPC channel options change";
 }
 
 // Test isReloadable() returns true when old config is null


### PR DESCRIPTION
## Summary

- Add Java-agent-style gRPC channel options for Agent, Metadata, Span, and Stat channels.
- Support optional TLS credentials through root/trust certificate file paths while keeping insecure channels as the default.
- Move keepalive, max message size, request timeout, and applicable sender queue settings into YAML/env config.
- Apply metadata options to the separate `GrpcMetadata` channel and document remaining Java-only differences.
- Extend config parsing, validation, string output, reload comparison, and tests.

## Validation

- `bash -lc "source scripts/dev-shell.sh; cmake --preset debug-cached"`
- `bash -lc "source scripts/dev-shell.sh; cmake --build --preset debug-cached"`
- `./build/debug-cached/test/test_config`
