### PR TITLE
[#83] Add gRPC agent command stream

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -39,12 +39,14 @@ namespace pinpoint {
                          std::unique_ptr<GrpcAgent> grpc_agent,
                          std::unique_ptr<GrpcMetadata> grpc_metadata,
                          std::unique_ptr<GrpcSpan> grpc_span,
-                         std::unique_ptr<GrpcStats> grpc_stat) :
+                         std::unique_ptr<GrpcStats> grpc_stat,
+                         std::unique_ptr<GrpcCommand> grpc_command) :
         config_(std::shared_ptr<const Config>(std::move(cfg))),
         grpc_agent_(std::move(grpc_agent)),
         grpc_metadata_(std::move(grpc_metadata)),
         grpc_span_(std::move(grpc_span)),
         grpc_stat_(std::move(grpc_stat)),
+        grpc_command_(std::move(grpc_command)),
         start_time_(to_milli_seconds(std::chrono::system_clock::now())),
         trace_id_sequence_(1) {
 
@@ -183,6 +185,9 @@ namespace pinpoint {
         grpc_metadata_->setAgentService(this);
         grpc_span_->setAgentService(this);
         grpc_stat_->setAgentService(this);
+        if (grpc_command_) {
+            grpc_command_->setAgentService(this);
+        }
 
         grpc_agent_->startAgentInfo();
 
@@ -190,6 +195,9 @@ namespace pinpoint {
         meta_thread_ = std::thread{&GrpcMetadata::sendMetaWorker, grpc_metadata_.get()};
         span_thread_ = std::thread{&GrpcSpan::sendSpanWorker, grpc_span_.get()};
         stat_thread_ = std::thread{&GrpcStats::sendStatsWorker, grpc_stat_.get()};
+        if (grpc_command_) {
+            command_thread_ = std::thread{&GrpcCommand::commandWorker, grpc_command_.get()};
+        }
         url_stat_add_thread_ = std::thread{&UrlStats::addUrlStatsWorker, url_stats_.get()};
         url_stat_send_thread_ = std::thread{&UrlStats::sendUrlStatsWorker, url_stats_.get()};
         agent_stat_thread_ = std::thread{&AgentStats::agentStatsWorker, agent_stats_.get()};
@@ -212,6 +220,9 @@ namespace pinpoint {
         grpc_metadata_->stopMetaWorker();
         grpc_span_->stopSpanWorker();
         grpc_stat_->stopStatsWorker();
+        if (grpc_command_) {
+            grpc_command_->stopCommandWorker();
+        }
 
         wait_grpc_workers();
 
@@ -219,6 +230,9 @@ namespace pinpoint {
         grpc_metadata_->closeChannel();
         grpc_stat_->closeChannel();
         grpc_span_->closeChannel();
+        if (grpc_command_) {
+            grpc_command_->closeChannel();
+        }
 
         LOG_INFO("close grpc workers done");
     }
@@ -241,6 +255,7 @@ namespace pinpoint {
             if (meta_thread_.joinable()) meta_thread_.join();
             if (span_thread_.joinable()) span_thread_.join();
             if (stat_thread_.joinable()) stat_thread_.join();
+            if (command_thread_.joinable()) command_thread_.join();
 
             {
                 std::unique_lock<std::mutex> l(state->m);
@@ -279,6 +294,7 @@ namespace pinpoint {
         safe_detach(meta_thread_);
         safe_detach(span_thread_);
         safe_detach(stat_thread_);
+        safe_detach(command_thread_);
         safe_detach(url_stat_add_thread_);
         safe_detach(url_stat_send_thread_);
         safe_detach(agent_stat_thread_);
@@ -555,8 +571,10 @@ namespace pinpoint {
             auto grpc_metadata = std::make_unique<GrpcMetadata>(cfg);
             auto grpc_span = std::make_unique<GrpcSpan>(cfg);
             auto grpc_stat = std::make_unique<GrpcStats>(cfg);
+            auto grpc_command = std::make_unique<GrpcCommand>(cfg);
             return std::make_shared<AgentImpl>(cfg,
-                std::move(grpc_agent), std::move(grpc_metadata), std::move(grpc_span), std::move(grpc_stat));
+                std::move(grpc_agent), std::move(grpc_metadata), std::move(grpc_span),
+                std::move(grpc_stat), std::move(grpc_command));
         } catch (const std::exception& e) {
             LOG_ERROR("make agent exception = {}", e.what());
             return nullptr;

--- a/src/agent.h
+++ b/src/agent.h
@@ -51,7 +51,8 @@ namespace pinpoint {
 				  std::unique_ptr<GrpcAgent> grpc_agent,
 				  std::unique_ptr<GrpcMetadata> grpc_metadata,
 				  std::unique_ptr<GrpcSpan> grpc_span,
-				  std::unique_ptr<GrpcStats> grpc_stat);
+				  std::unique_ptr<GrpcStats> grpc_stat,
+				  std::unique_ptr<GrpcCommand> grpc_command = nullptr);
         ~AgentImpl() noexcept override;
 
 		/**
@@ -130,6 +131,7 @@ namespace pinpoint {
     	std::unique_ptr<GrpcMetadata> grpc_metadata_{};
     	std::unique_ptr<GrpcSpan> grpc_span_{};
     	std::unique_ptr<GrpcStats> grpc_stat_{};
+	std::unique_ptr<GrpcCommand> grpc_command_{};
     	std::unique_ptr<UrlStats> url_stats_{};
     	std::unique_ptr<AgentStats> agent_stats_{};
 
@@ -138,6 +140,7 @@ namespace pinpoint {
     	std::thread meta_thread_;
     	std::thread span_thread_;
     	std::thread stat_thread_;
+	std::thread command_thread_;
     	std::thread url_stat_add_thread_;
     	std::thread url_stat_send_thread_;
     	std::thread agent_stat_thread_;

--- a/src/grpc.cpp
+++ b/src/grpc.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <cassert>
+#include <algorithm>
 #include <fstream>
 #include <limits>
 #include <memory>
@@ -492,6 +493,7 @@ namespace pinpoint {
     const std::string METADATA_SERVICE_TYPE = "servicetype";
     const std::string METADATA_AGENT_NAME = "agentname";
     const std::string METADATA_SOCKET_ID = "socketid";
+    const std::string METADATA_SUPPORT_COMMAND_CODE = "supportcommandcode";
 
     void GrpcClient::build_grpc_context(grpc::ClientContext* context, unsigned long socket_id) const {
         assert(agent_ != nullptr && "setAgentService() must be called before build_grpc_context()");
@@ -810,6 +812,364 @@ namespace pinpoint {
     void GrpcMetadata::stopMetaWorker() {
         std::unique_lock<std::mutex> lock(meta_queue_mutex_);
         meta_queue_cv_.notify_all();
+    }
+
+    //GrpcCommand
+
+    namespace {
+        constexpr int ACTIVE_TRACE_HISTOGRAM_SCHEMA_TYPE = 2;
+        constexpr auto COMMAND_RECONNECT_DELAY = std::chrono::milliseconds(1000);
+        constexpr auto ACTIVE_THREAD_COUNT_FLUSH_DELAY = std::chrono::milliseconds(1000);
+
+        int32_t command_code(const v1::PCmdRequest& request) {
+            return static_cast<int32_t>(request.command_case());
+        }
+
+        std::string support_command_code_header(const std::vector<int32_t>& command_codes) {
+            std::string value;
+            for (auto code : command_codes) {
+                if (!value.empty()) {
+                    value.append(";");
+                }
+                value.append(std::to_string(code));
+            }
+            return value;
+        }
+    }
+
+    void GrpcCommandDispatcher::registerHandler(int32_t command_code, Handler handler) {
+        handlers_[command_code] = std::move(handler);
+    }
+
+    std::vector<int32_t> GrpcCommandDispatcher::supportedCommandCodes() const {
+        std::vector<int32_t> codes;
+        codes.reserve(handlers_.size());
+        for (const auto& [code, handler] : handlers_) {
+            codes.push_back(code);
+        }
+        std::sort(codes.begin(), codes.end());
+        return codes;
+    }
+
+    bool GrpcCommandDispatcher::handle(
+            const v1::PCmdRequest& request,
+            grpc::ClientReaderWriterInterface<v1::PCmdMessage, v1::PCmdRequest>* stream) const {
+        const auto code = command_code(request);
+        const auto handler = handlers_.find(code);
+        if (handler == handlers_.end()) {
+            v1::PCmdMessage fail_message;
+            auto* fail = fail_message.mutable_failmessage();
+            fail->set_responseid(request.requestid());
+            fail->mutable_message()->set_value("NOT_SUPPORTED_REQUEST");
+            return stream == nullptr || stream->Write(fail_message);
+        }
+        return handler->second(request, stream);
+    }
+
+    class GrpcCommand::ActiveThreadCountStream {
+    public:
+        ActiveThreadCountStream(GrpcCommand* owner, unsigned long socket_id, int32_t request_id)
+            : owner_(owner), socket_id_(socket_id), request_id_(request_id) {}
+
+        ~ActiveThreadCountStream() {
+            stop();
+        }
+
+        void start() {
+            worker_ = std::thread{&ActiveThreadCountStream::run, this};
+        }
+
+        void stop() {
+            stop_requested_ = true;
+            {
+                std::unique_lock<std::mutex> lock(context_mutex_);
+                if (context_ != nullptr) {
+                    context_->TryCancel();
+                }
+            }
+            cv_.notify_all();
+            if (worker_.joinable()) {
+                worker_.join();
+            }
+        }
+
+        bool done() const {
+            return done_;
+        }
+
+    private:
+        GrpcCommand* owner_;
+        unsigned long socket_id_;
+        int32_t request_id_;
+        std::atomic<bool> stop_requested_{false};
+        std::atomic<bool> done_{false};
+        std::thread worker_;
+        std::mutex context_mutex_;
+        std::unique_ptr<grpc::ClientContext> context_{nullptr};
+        std::mutex cv_mutex_;
+        std::condition_variable cv_;
+
+        void run() try {
+            auto context = std::make_unique<grpc::ClientContext>();
+            owner_->build_command_context(context.get(), socket_id_);
+            {
+                std::unique_lock<std::mutex> lock(context_mutex_);
+                context_ = std::move(context);
+            }
+
+            google::protobuf::Empty reply;
+            auto writer = owner_->command_stub_->CommandStreamActiveThreadCount(context_.get(), &reply);
+            if (writer == nullptr) {
+                LOG_WARN("failed to start active thread count stream: writer is null");
+                {
+                    std::unique_lock<std::mutex> lock(context_mutex_);
+                    context_.reset();
+                }
+                done_ = true;
+                return;
+            }
+
+            int32_t sequence_id = 0;
+            while (!stop_requested_ && !owner_->agent_->isExiting()) {
+                v1::PCmdActiveThreadCountRes response;
+                owner_->build_active_thread_count_response(&response, request_id_, ++sequence_id);
+                if (!writer->Write(response)) {
+                    LOG_INFO("active thread count stream write failed: requestId={}, socketId={}", request_id_, socket_id_);
+                    break;
+                }
+
+                std::unique_lock<std::mutex> lock(cv_mutex_);
+                cv_.wait_for(lock, ACTIVE_THREAD_COUNT_FLUSH_DELAY, [this] {
+                    return stop_requested_.load() || owner_->agent_->isExiting();
+                });
+            }
+
+            writer->WritesDone();
+            const auto status = writer->Finish();
+            if (!status.ok() && !stop_requested_ && !owner_->agent_->isExiting()) {
+                LOG_INFO("active thread count stream closed: {}, {}",
+                         static_cast<int>(status.error_code()), status.error_message());
+            }
+            {
+                std::unique_lock<std::mutex> lock(context_mutex_);
+                context_.reset();
+            }
+            done_ = true;
+        } catch (const std::exception& e) {
+            {
+                std::unique_lock<std::mutex> lock(context_mutex_);
+                context_.reset();
+            }
+            LOG_ERROR("active thread count stream exception = {}", e.what());
+            done_ = true;
+        }
+    };
+
+    GrpcCommand::GrpcCommand(std::shared_ptr<const Config> config) : GrpcClient(AGENT, std::move(config)) {
+        set_command_stub(v1::ProfilerCommandService::NewStub(channel_));
+        register_default_handlers();
+    }
+
+    GrpcCommand::~GrpcCommand() {
+        stopCommandWorker();
+    }
+
+    void GrpcCommand::register_default_handlers() {
+        dispatcher_.registerHandler(static_cast<int32_t>(v1::ECHO),
+            [this](const v1::PCmdRequest& request,
+                   grpc::ClientReaderWriterInterface<v1::PCmdMessage, v1::PCmdRequest>* stream) {
+                return handle_echo(request, stream);
+            });
+        dispatcher_.registerHandler(static_cast<int32_t>(v1::ACTIVE_THREAD_COUNT),
+            [this](const v1::PCmdRequest& request,
+                   grpc::ClientReaderWriterInterface<v1::PCmdMessage, v1::PCmdRequest>* stream) {
+                return handle_active_thread_count(request, stream);
+            });
+    }
+
+    void GrpcCommand::build_command_context(grpc::ClientContext* context, unsigned long socket_id) const {
+        build_grpc_context(context, socket_id);
+    }
+
+    bool GrpcCommand::write_fail_message(
+            const v1::PCmdRequest& request,
+            grpc::ClientReaderWriterInterface<v1::PCmdMessage, v1::PCmdRequest>* stream,
+            std::string_view message) const {
+        if (stream == nullptr) {
+            return false;
+        }
+
+        v1::PCmdMessage fail_message;
+        auto* fail = fail_message.mutable_failmessage();
+        fail->set_responseid(request.requestid());
+        fail->mutable_message()->set_value(std::string(message));
+        return stream->Write(fail_message);
+    }
+
+    bool GrpcCommand::handle_echo(
+            const v1::PCmdRequest& request,
+            grpc::ClientReaderWriterInterface<v1::PCmdMessage, v1::PCmdRequest>* stream) {
+        if (!request.has_commandecho()) {
+            return write_fail_message(request, stream, "invalid echo command");
+        }
+
+        grpc::ClientContext ctx;
+        google::protobuf::Empty reply;
+        v1::PCmdEchoResponse response;
+
+        build_command_context(&ctx, 0);
+        set_deadline(ctx, config_->grpc.agent.request_timeout_ms);
+
+        response.mutable_commonresponse()->set_responseid(request.requestid());
+        response.set_message(request.commandecho().message());
+
+        const auto status = command_stub_->CommandEcho(&ctx, response, &reply);
+        if (!status.ok()) {
+            LOG_INFO("command echo response failed: {}, {}",
+                     static_cast<int>(status.error_code()), status.error_message());
+            return write_fail_message(request, stream, status.error_message());
+        }
+        return true;
+    }
+
+    bool GrpcCommand::handle_active_thread_count(
+            const v1::PCmdRequest& request,
+            grpc::ClientReaderWriterInterface<v1::PCmdMessage, v1::PCmdRequest>* stream) {
+        if (!request.has_commandactivethreadcount()) {
+            return write_fail_message(request, stream, "invalid active thread count command");
+        }
+
+        add_active_thread_count_stream(request.requestid());
+        return true;
+    }
+
+    void GrpcCommand::build_active_thread_count_response(
+            v1::PCmdActiveThreadCountRes* response,
+            int32_t request_id,
+            int32_t sequence_id) const {
+        const auto now = to_milli_seconds(std::chrono::system_clock::now());
+        int32_t active_requests[4]{0, 0, 0, 0};
+        agent_->getAgentStats().collectActiveRequests(active_requests, now);
+
+        auto* header = response->mutable_commonstreamresponse();
+        header->set_responseid(request_id);
+        header->set_sequenceid(sequence_id);
+        response->set_histogramschematype(ACTIVE_TRACE_HISTOGRAM_SCHEMA_TYPE);
+        response->set_timestamp(now);
+
+        for (const auto count : active_requests) {
+            response->add_activethreadcount(count);
+        }
+    }
+
+    void GrpcCommand::add_active_thread_count_stream(int32_t request_id) {
+        std::unique_lock<std::mutex> lock(active_streams_mutex_);
+        cleanup_active_thread_count_streams();
+
+        auto stream = std::make_unique<ActiveThreadCountStream>(this, ++socket_id_, request_id);
+        stream->start();
+        active_thread_count_streams_.push_back(std::move(stream));
+        LOG_INFO("active thread count stream started: requestId={}", request_id);
+    }
+
+    void GrpcCommand::cleanup_active_thread_count_streams() {
+        active_thread_count_streams_.erase(
+            std::remove_if(active_thread_count_streams_.begin(), active_thread_count_streams_.end(),
+                [](const auto& stream) { return stream->done(); }),
+            active_thread_count_streams_.end());
+    }
+
+    void GrpcCommand::stop_active_thread_count_streams() {
+        std::vector<std::unique_ptr<ActiveThreadCountStream>> streams;
+        {
+            std::unique_lock<std::mutex> lock(active_streams_mutex_);
+            streams.swap(active_thread_count_streams_);
+        }
+        for (auto& stream : streams) {
+            stream->stop();
+        }
+    }
+
+    void GrpcCommand::cancel_command_stream() {
+        std::unique_lock<std::mutex> lock(command_worker_mutex_);
+        if (command_stream_context_ != nullptr) {
+            command_stream_context_->TryCancel();
+        }
+        command_worker_cv_.notify_all();
+    }
+
+    bool GrpcCommand::wait_reconnect_delay(std::chrono::milliseconds delay) {
+        std::unique_lock<std::mutex> lock(command_worker_mutex_);
+        return command_worker_cv_.wait_for(lock, delay, [this] {
+            return agent_->isExiting();
+        });
+    }
+
+    void GrpcCommand::commandWorker() try {
+        while (!agent_->isExiting()) {
+            if (!readyChannel()) {
+                break;
+            }
+
+            grpc::ClientContext context;
+            build_command_context(&context, ++socket_id_);
+            const auto command_codes = dispatcher_.supportedCommandCodes();
+            context.AddMetadata(METADATA_SUPPORT_COMMAND_CODE, support_command_code_header(command_codes));
+
+            {
+                std::unique_lock<std::mutex> lock(command_worker_mutex_);
+                command_stream_context_ = &context;
+            }
+
+            LOG_INFO("connect to command service stream");
+            auto stream = command_stub_->HandleCommandV2(&context);
+            if (stream == nullptr) {
+                LOG_WARN("failed to connect to command service stream: stream is null");
+            } else {
+                v1::PCmdRequest request;
+                while (!agent_->isExiting() && stream->Read(&request)) {
+                    LOG_DEBUG("received command request: requestId={}, commandCode={}",
+                              request.requestid(), command_code(request));
+                    const auto handled = dispatcher_.handle(request, stream.get());
+                    request.Clear();
+                    if (!handled) {
+                        LOG_INFO("command stream write failed while handling request");
+                        break;
+                    }
+                }
+                stream->WritesDone();
+                const auto status = stream->Finish();
+                if (!status.ok() && !agent_->isExiting()) {
+                    LOG_INFO("command service stream closed: {}, {}",
+                             static_cast<int>(status.error_code()), status.error_message());
+                } else {
+                    LOG_INFO("command service stream completed");
+                }
+            }
+
+            {
+                std::unique_lock<std::mutex> lock(command_worker_mutex_);
+                command_stream_context_ = nullptr;
+            }
+            {
+                std::unique_lock<std::mutex> lock(active_streams_mutex_);
+                cleanup_active_thread_count_streams();
+            }
+
+            if (agent_->isExiting() || wait_reconnect_delay(COMMAND_RECONNECT_DELAY)) {
+                break;
+            }
+        }
+        stop_active_thread_count_streams();
+        LOG_INFO("grpc command worker end");
+    } catch (const std::exception& e) {
+        LOG_ERROR("grpc command worker exception = {}", e.what());
+        stop_active_thread_count_streams();
+    }
+
+    void GrpcCommand::stopCommandWorker() {
+        cancel_command_stream();
+        stop_active_thread_count_streams();
     }
 
     //GrpcAgent

--- a/src/grpc.h
+++ b/src/grpc.h
@@ -20,12 +20,14 @@
 #include <chrono>
 #include <condition_variable>
 #include <map>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <deque>
 #include <queue>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -250,6 +252,73 @@ namespace pinpoint {
         void release_failed_cache(const MetaData& meta) const;
         void schedule_retry(PendingMeta&& pending);
         bool pop_next_meta(PendingMeta& pending, std::unique_lock<std::mutex>& lock);
+    };
+
+    /**
+     * @brief Dispatcher for collector-originated profiler commands.
+     */
+    class GrpcCommandDispatcher {
+    public:
+        using Handler = std::function<bool(const v1::PCmdRequest&, grpc::ClientReaderWriterInterface<v1::PCmdMessage, v1::PCmdRequest>*)>;
+
+        void registerHandler(int32_t command_code, Handler handler);
+        bool handle(const v1::PCmdRequest& request,
+                    grpc::ClientReaderWriterInterface<v1::PCmdMessage, v1::PCmdRequest>* stream) const;
+        std::vector<int32_t> supportedCommandCodes() const;
+
+    private:
+        std::unordered_map<int32_t, Handler> handlers_{};
+    };
+
+    /**
+     * @brief gRPC client responsible for the profiler command stream.
+     */
+    class GrpcCommand : public GrpcClient {
+    public:
+        explicit GrpcCommand(std::shared_ptr<const Config> config);
+        ~GrpcCommand() override;
+
+        /// @brief Worker loop that receives collector commands and dispatches them.
+        void commandWorker();
+        /// @brief Stops the command stream worker and any active response streams.
+        void stopCommandWorker();
+
+    protected:
+        void set_command_stub(std::unique_ptr<v1::ProfilerCommandService::StubInterface> stub) {
+            command_stub_ = std::move(stub);
+        }
+
+    private:
+        class ActiveThreadCountStream;
+
+        std::unique_ptr<v1::ProfilerCommandService::StubInterface> command_stub_{};
+        GrpcCommandDispatcher dispatcher_{};
+
+        std::mutex command_worker_mutex_{};
+        std::condition_variable command_worker_cv_{};
+        grpc::ClientContext* command_stream_context_{nullptr};
+        unsigned long socket_id_{0};
+
+        std::mutex active_streams_mutex_{};
+        std::vector<std::unique_ptr<ActiveThreadCountStream>> active_thread_count_streams_{};
+
+        void register_default_handlers();
+        bool handle_echo(const v1::PCmdRequest& request,
+                         grpc::ClientReaderWriterInterface<v1::PCmdMessage, v1::PCmdRequest>* stream);
+        bool handle_active_thread_count(const v1::PCmdRequest& request,
+                                        grpc::ClientReaderWriterInterface<v1::PCmdMessage, v1::PCmdRequest>* stream);
+        void build_command_context(grpc::ClientContext* context, unsigned long socket_id) const;
+        void build_active_thread_count_response(v1::PCmdActiveThreadCountRes* response,
+                                                int32_t request_id,
+                                                int32_t sequence_id) const;
+        void add_active_thread_count_stream(int32_t request_id);
+        void cleanup_active_thread_count_streams();
+        void stop_active_thread_count_streams();
+        bool write_fail_message(const v1::PCmdRequest& request,
+                                grpc::ClientReaderWriterInterface<v1::PCmdMessage, v1::PCmdRequest>* stream,
+                                std::string_view message) const;
+        void cancel_command_stream();
+        bool wait_reconnect_delay(std::chrono::milliseconds delay);
     };
 
     /**

--- a/src/stat.cpp
+++ b/src/stat.cpp
@@ -268,6 +268,27 @@ namespace pinpoint {
         active_span_map_.erase(spanId);
     }
 
+    void AgentStats::collectActiveRequests(int32_t active_requests[4], int64_t sample_time_ms) {
+        active_requests[0] = 0;
+        active_requests[1] = 0;
+        active_requests[2] = 0;
+        active_requests[3] = 0;
+
+        std::lock_guard<std::mutex> lock(active_span_mutex_);
+        for (const auto& iter : active_span_map_) {
+            auto active_time = sample_time_ms - iter.second;
+            if (active_time < 1000) {
+                active_requests[0]++;
+            } else if (active_time < 3000) {
+                active_requests[1]++;
+            } else if (active_time < 5000) {
+                active_requests[2]++;
+            } else {
+                active_requests[3]++;
+            }
+        }
+    }
+
     void AgentStats::collectAgentStat(AgentStatsSnapshot &stat) {
         std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
         std::chrono::seconds period = std::chrono::duration_cast<std::chrono::seconds>(now - last_collect_time_);
@@ -309,26 +330,7 @@ namespace pinpoint {
         stat.num_skip_new_ = skip_new_.exchange(0);
         stat.num_skip_cont_ = skip_cont_.exchange(0);
 
-        stat.active_requests_[0] = 0;
-        stat.active_requests_[1] = 0;
-        stat.active_requests_[2] = 0;
-        stat.active_requests_[3] = 0;
-
-        {
-            std::lock_guard<std::mutex> lock(active_span_mutex_);
-            for (const auto& iter : active_span_map_) {
-                auto active_time = stat.sample_time_ - iter.second;
-                if (active_time < 1000) {
-                    stat.active_requests_[0]++;
-                } else if (active_time < 3000) {
-                    stat.active_requests_[1]++;
-                } else if (active_time < 5000) {
-                    stat.active_requests_[2]++;
-                } else {
-                    stat.active_requests_[3]++;
-                }
-            }
-        }
+        collectActiveRequests(stat.active_requests_, stat.sample_time_);
     }
 
     void AgentStats::agentStatsWorker() try {

--- a/src/stat.h
+++ b/src/stat.h
@@ -83,6 +83,7 @@ namespace pinpoint {
 
         void initAgentStats();
         void collectAgentStat(AgentStatsSnapshot &stat);
+        void collectActiveRequests(int32_t active_requests[4], int64_t sample_time_ms);
         void resetAgentStats();
 
     private:

--- a/test/test_stat.cpp
+++ b/test/test_stat.cpp
@@ -535,6 +535,29 @@ TEST_F(StatTest, AllSpansInOneBucketTest) {
     }
 }
 
+TEST_F(StatTest, CollectActiveRequestsMatchesHistogramBucketsTest) {
+    auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+
+    agent_stats_->addActiveSpan(3001, now_ms - 100);
+    agent_stats_->addActiveSpan(3002, now_ms - 1200);
+    agent_stats_->addActiveSpan(3003, now_ms - 3200);
+    agent_stats_->addActiveSpan(3004, now_ms - 5200);
+
+    int32_t active_requests[4]{};
+    agent_stats_->collectActiveRequests(active_requests, now_ms);
+
+    EXPECT_EQ(active_requests[0], 1);
+    EXPECT_EQ(active_requests[1], 1);
+    EXPECT_EQ(active_requests[2], 1);
+    EXPECT_EQ(active_requests[3], 1);
+
+    agent_stats_->dropActiveSpan(3001);
+    agent_stats_->dropActiveSpan(3002);
+    agent_stats_->dropActiveSpan(3003);
+    agent_stats_->dropActiveSpan(3004);
+}
+
 // Test empty active span map
 TEST_F(StatTest, EmptyActiveSpanMapTest) {
     AgentStatsSnapshot snapshot;


### PR DESCRIPTION
## Summary

Add Java-agent-compatible gRPC Agent command stream support to the C++ Pinpoint agent.

Closes #83

## Changes

- Add `GrpcCommand` for `ProfilerCommandService.HandleCommandV2`
- Add command dispatcher with command-code handler registration
- Add command stream metadata for agent identity, `socketid`, and `supportcommandcode`
- Reconnect command stream independently from the ping stream
- Stop/cancel command stream and active response streams during shutdown
- Implement Echo command `710`
- Implement Active Thread Count command `730`
- Reuse the existing active request histogram buckets without resetting periodic stat counters
- Add a focused unit test for active request bucket mapping

## Java Compatibility

Active Thread Count uses the same four-bucket schema as the existing agent stat logic:

- `< 1000ms`
- `< 3000ms`
- `< 5000ms`
- `>= 5000ms`

The response uses `histogramSchemaType = 2`.

## Known Differences / Limitations

Active Thread Dump `740` and Active Thread Light Dump `750` are not implemented or advertised yet.

The C++ runtime currently does not maintain Java-style thread stack or active transaction snapshot data required to populate those proto messages with equivalent semantics. Unsupported command requests return a fail message with `NOT_SUPPORTED_REQUEST`.

## Verification

- `cmake --preset debug-cached`
- `cmake --build --preset debug-cached`
- `test_stat --gtest_filter=StatTest.CollectActiveRequestsMatchesHistogramBucketsTest`