### PR TITLE
[#noissue] Optimize URL stat pipeline hot path

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -504,7 +504,7 @@ namespace pinpoint {
         }
     }
 
-    void AgentImpl::recordUrlStat(std::unique_ptr<UrlStatEntry> stat) const {
+    void AgentImpl::recordUrlStat(UrlStatEntry stat) const {
         if (enabled_) {
             url_stats_->enqueueUrlStats(std::move(stat));
         }

--- a/src/agent.h
+++ b/src/agent.h
@@ -105,7 +105,7 @@ namespace pinpoint {
 
     	TraceId generateTraceId() override;
     	void recordSpan(std::unique_ptr<SpanChunk> span) const override;
-    	void recordUrlStat(std::unique_ptr<UrlStatEntry> stat) const override;
+    	void recordUrlStat(UrlStatEntry stat) const override;
     	void recordException(SpanData* span_data) const override;
     	void recordStats(StatsType stats) const override;
 

--- a/src/agent_service.h
+++ b/src/agent_service.h
@@ -113,7 +113,7 @@
        *
        * @param stat URL statistic record to be transferred.
        */
-      virtual void recordUrlStat(std::unique_ptr<UrlStatEntry> stat) const = 0;
+      virtual void recordUrlStat(UrlStatEntry stat) const = 0;
       /**
        * @brief Reports an exception captured during span processing.
        *

--- a/src/noop.cpp
+++ b/src/noop.cpp
@@ -45,7 +45,7 @@ namespace pinpoint {
     UnsampledSpan::UnsampledSpan(AgentService *agent) : NoopSpan(),
         span_id_(generate_span_id()),
         start_time_(to_milli_seconds(std::chrono::system_clock::now())),
-        url_stat_(nullptr),
+        url_stat_(),
         agent_ref_(agent != nullptr ? agent->selfRef() : nullptr),
         agent_(agent) {
         // Guard the deref to stay consistent with the null check on agent_ref_
@@ -80,12 +80,13 @@ namespace pinpoint {
         if (url_stat_) {
             url_stat_->end_time_ = end_time_;
             url_stat_->elapsed_ = elapsed_;
-            agent_->recordUrlStat(std::move(url_stat_));
+            agent_->recordUrlStat(std::move(*url_stat_));
+            url_stat_.reset();
         }
     }
 
     void UnsampledSpan::SetUrlStat(std::string_view url_pattern, std::string_view method, int status_code) try {
-        url_stat_ = std::make_unique<UrlStatEntry>(url_pattern, method, status_code);
+        url_stat_.emplace(url_pattern, method, status_code);
     } catch (const std::exception& e) {
         LOG_ERROR("set url stat exception = {}", e.what());
     }
@@ -94,4 +95,3 @@ namespace pinpoint {
         writer.Set(HEADER_SAMPLED, "s0");
     }
 }
-

--- a/src/noop.h
+++ b/src/noop.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <atomic>
+#include <optional>
 #include <vector>
 
 #include "pinpoint/tracer.h"
@@ -149,7 +150,7 @@ namespace pinpoint {
         int64_t span_id_;
         int64_t start_time_;
         std::atomic<bool> finished_{false};
-        std::unique_ptr<UrlStatEntry> url_stat_;
+        std::optional<UrlStatEntry> url_stat_;
         // Keeps the agent alive while user code still holds this span.
         std::shared_ptr<AgentService> agent_ref_;
         AgentService *agent_;

--- a/src/span.cpp
+++ b/src/span.cpp
@@ -135,7 +135,7 @@ namespace pinpoint {
     }
 
     void SpanData::setUrlStat(std::string_view url_pattern, std::string_view method, int status_code) try {
-        url_stat_ = std::make_unique<UrlStatEntry>(url_pattern, method, status_code);
+        url_stat_.emplace(url_pattern, method, status_code);
     } catch (const std::exception& e) {
         LOG_ERROR("set url stat exception = {}", e.what());
     }
@@ -145,7 +145,8 @@ namespace pinpoint {
             url_stat_->end_time_ = end_time_;
             url_stat_->elapsed_ = elapsed_;
             url_stat_->failed_ = agent_->isStatusFail(url_stat_->status_code_);
-            agent_->recordUrlStat(std::move(url_stat_));
+            agent_->recordUrlStat(std::move(*url_stat_));
+            url_stat_.reset();
         }
     }
 

--- a/src/span.h
+++ b/src/span.h
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <stack>
 #include <string>
 #include <vector>
@@ -359,7 +360,7 @@ namespace pinpoint {
     	// mutable so const accessors (getFinishedEventsCount) can lock it.
     	mutable std::mutex span_event_lock_;
 
-        std::unique_ptr<UrlStatEntry> url_stat_;
+        std::optional<UrlStatEntry> url_stat_;
     	std::shared_ptr<PinpointAnnotation> annotations_;
         std::vector<std::unique_ptr<Exception>> exceptions_;
     	// Keeps the agent alive while this span (or any chunk/event referencing

--- a/src/url_stat.cpp
+++ b/src/url_stat.cpp
@@ -16,7 +16,6 @@
 
 #include <mutex>
 
-#include "absl/strings/str_cat.h"
 #include "logging.h"
 #include "url_stat.h"
 
@@ -34,6 +33,59 @@ namespace pinpoint {
     constexpr int32_t BUCKET_THRESHOLD_3S = 3000;
     constexpr int32_t BUCKET_THRESHOLD_5S = 5000;
     constexpr int32_t BUCKET_THRESHOLD_8S = 8000;
+
+    struct TrimmedUrlPath {
+        std::string_view path;
+        bool wildcard;
+    };
+
+    static TrimmedUrlPath trim_url_path_view(std::string_view url, int depth) noexcept {
+        if (url.empty()) {
+            return {url, false};
+        }
+
+        if (depth < 1) {
+            depth = 1;
+        }
+
+        size_t end = url.size();
+        bool wildcard = false;
+        for (size_t i = 1; i < url.size(); i++) {
+            if (url[i] == '?') {
+                end = i;
+                break;
+            }
+            if (url[i] == '/') {
+                depth--;
+                if (depth == 0) {
+                    end = i + 1;
+                    wildcard = true;
+                    break;
+                }
+            }
+        }
+
+        return {url.substr(0, end), wildcard};
+    }
+
+    static std::string build_url_stat_key(const UrlStatEntry& us, const Config& config) {
+        const auto trimmed = config.http.url_stat.enable_trim_path
+            ? trim_url_path_view(us.url_pattern_, config.http.url_stat.trim_path_depth)
+            : TrimmedUrlPath{us.url_pattern_, false};
+
+        const auto method_prefix_size = config.http.url_stat.method_prefix ? us.method_.size() + 1 : 0;
+        std::string url;
+        url.reserve(method_prefix_size + trimmed.path.size() + (trimmed.wildcard ? 1 : 0));
+        if (config.http.url_stat.method_prefix) {
+            url.append(us.method_);
+            url.push_back(' ');
+        }
+        url.append(trimmed.path.data(), trimmed.path.size());
+        if (trimmed.wildcard) {
+            url.push_back('*');
+        }
+        return url;
+    }
     
     UrlStats::UrlStats(AgentService* agent)
         : agent_(agent),
@@ -79,16 +131,12 @@ namespace pinpoint {
     }
 
     void UrlStatSnapshot::add(const UrlStatEntry* us, const Config& config, TickClock& tick_clock) {
-        std::unique_lock<std::mutex> lock(mutex_);
-
-        auto url = config.http.url_stat.enable_trim_path ? 
-            trim_url_path(us->url_pattern_, config.http.url_stat.trim_path_depth) : us->url_pattern_;
-
-        if (config.http.url_stat.method_prefix) {
-            url = absl::StrCat(us->method_, " ", url);
+        if (us == nullptr) {
+            return;
         }
 
-        const auto key = UrlKey{url, tick_clock.tick(us->end_time_)};
+        const auto tick = tick_clock.tick(us->end_time_);
+        auto key = UrlKey{build_url_stat_key(*us, config), tick};
         LOG_DEBUG("url stats snapshot add : {}, {}", key.url_, key.tick_);
 
         EachUrlStat *e;
@@ -96,9 +144,13 @@ namespace pinpoint {
             if (urlMap_.size() >= static_cast<size_t>(config.http.url_stat.limit)) {
                 return;
             }
+            if (urlMap_.empty() && config.http.url_stat.limit > 0) {
+                constexpr size_t kMaxInitialReserve = 4096;
+                urlMap_.reserve(std::min(static_cast<size_t>(config.http.url_stat.limit), kMaxInitialReserve));
+            }
             auto new_stat = std::make_unique<EachUrlStat>(key.tick_);
             e = new_stat.get();
-            urlMap_[key] = std::move(new_stat);
+            urlMap_.emplace(std::move(key), std::move(new_stat));
         } else {
             e = f->second.get();
         }
@@ -110,40 +162,28 @@ namespace pinpoint {
     }
 
     std::string UrlStatSnapshot::trim_url_path(std::string_view url, int depth) {
-        if (url.empty()) {
-            return "";
-        }
-        
-        if (depth < 1) { 
-            depth = 1; 
-        }
-
+        const auto trimmed = trim_url_path_view(url, depth);
         std::string result;
-        result.reserve(url.size());  // Pre-allocate to avoid reallocation
-        result += url[0];
-        
-        bool tailing = false;
-        for (size_t i = 1; i < url.size(); i++) {
-            if (url[i] == '?') {
-                break;
-            }
-            result += url[i];
-            if (url[i] == '/') {
-                depth--;
-                if (depth == 0) {
-                    tailing = true;
-                    break;
-                }
-            }
-        }
-        
-        if (tailing) {
-            result += '*';
+        result.reserve(trimmed.path.size() + (trimmed.wildcard ? 1 : 0));
+        result.append(trimmed.path.data(), trimmed.path.size());
+        if (trimmed.wildcard) {
+            result.push_back('*');
         }
         return result;
     }
 
     void UrlStats::enqueueUrlStats(std::unique_ptr<UrlStatEntry> stats) noexcept try {
+        if (!stats) {
+            return;
+        }
+        enqueueUrlStats(std::move(*stats));
+    } catch (const std::exception &e) {
+        LOG_ERROR("failed to enqueue url stats: exception = {}", e.what());
+    } catch (...) {
+        LOG_ERROR("failed to enqueue url stats: unknown exception");
+    }
+
+    void UrlStats::enqueueUrlStats(UrlStatEntry stats) noexcept try {
         const auto config = agent_->getConfig();
         if (!config->http.url_stat.enable) {
             return;
@@ -153,11 +193,11 @@ namespace pinpoint {
 
         if (url_stats_.size() < config->span.queue_size) {
             url_stats_.push(std::move(stats));
+            lock.unlock();
+            add_cond_var_.notify_one();
         } else {
             LOG_DEBUG("drop url stats: overflow max queue size {}", config->span.queue_size);
         }
-
-        add_cond_var_.notify_one();
     } catch (const std::exception &e) {
         LOG_ERROR("failed to enqueue url stats: exception = {}", e.what());
     } catch (...) {
@@ -171,6 +211,7 @@ namespace pinpoint {
         }
 
         std::unique_lock<std::mutex> lock(add_mutex_);
+        std::queue<UrlStatEntry> batch;
         while (!agent_->isExiting()) {
             add_cond_var_.wait(lock, [this] {
                 return !url_stats_.empty() || agent_->isExiting();
@@ -179,10 +220,16 @@ namespace pinpoint {
                 break;
             }
 
-            auto us = std::move(url_stats_.front());
-            url_stats_.pop();
+            batch.swap(url_stats_);
             lock.unlock();
-            addSnapshot(us.get(), *config);
+            {
+                std::lock_guard<std::mutex> snapshot_lock(snapshot_mutex_);
+                while (!batch.empty()) {
+                    auto us = std::move(batch.front());
+                    batch.pop();
+                    snapshot_->add(&us, *config, tick_clock_);
+                }
+            }
             lock.lock();
         }
         LOG_INFO("add url stats worker end");
@@ -198,7 +245,6 @@ namespace pinpoint {
             return;
         }
 
-        std::unique_lock<std::mutex> lock(add_mutex_);
         add_cond_var_.notify_one();
     }
 
@@ -230,7 +276,6 @@ namespace pinpoint {
             return;
         }
 
-        std::unique_lock<std::mutex> lock(send_mutex_);
         send_cond_var_.notify_one();
     }
 }

--- a/src/url_stat.h
+++ b/src/url_stat.h
@@ -19,11 +19,13 @@
 #include <algorithm>
 #include <chrono>
 #include <condition_variable>
-#include <map>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <queue>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 
 #include "config.h"
 #include "agent_service.h"
@@ -117,6 +119,17 @@ namespace pinpoint {
             }
             return tick_ < o.tick_;
         }
+        bool operator==(const UrlKey &o) const {
+            return tick_ == o.tick_ && url_ == o.url_;
+        }
+    };
+
+    struct UrlKeyHash {
+        size_t operator()(const UrlKey& key) const noexcept {
+            const auto url_hash = std::hash<std::string>{}(key.url_);
+            const auto tick_hash = std::hash<int64_t>{}(key.tick_);
+            return url_hash ^ (tick_hash + 0x9e3779b97f4a7c15ULL + (url_hash << 6) + (url_hash >> 2));
+        }
     };
 
     /**
@@ -140,7 +153,9 @@ namespace pinpoint {
      */
     class UrlStatSnapshot {
     public:
-        UrlStatSnapshot() : urlMap_{}, mutex_() {}
+        using UrlStatMap = std::unordered_map<UrlKey, std::unique_ptr<EachUrlStat>, UrlKeyHash>;
+
+        UrlStatSnapshot() : urlMap_{} {}
         ~UrlStatSnapshot() = default;
         
         /**
@@ -152,7 +167,7 @@ namespace pinpoint {
          */
         void add(const UrlStatEntry* us, const Config& config, TickClock& tick_clock);
         /// @brief Returns the const map storing statistics per URL/tick.
-        const std::map<UrlKey, std::unique_ptr<EachUrlStat>>& getEachStats() const { return urlMap_; }
+        const UrlStatMap& getEachStats() const { return urlMap_; }
 
         /**
          * @brief Trims a URL path using the configured depth.
@@ -163,8 +178,7 @@ namespace pinpoint {
         static std::string trim_url_path(std::string_view url, int depth);
 
     private:
-        std::map<UrlKey, std::unique_ptr<EachUrlStat>> urlMap_;
-        std::mutex mutex_;
+        UrlStatMap urlMap_;
     };
 
     /**
@@ -181,6 +195,7 @@ namespace pinpoint {
          * @param stats URL statistic entry (ownership transferred).
          */
         void enqueueUrlStats(std::unique_ptr<UrlStatEntry> stats) noexcept;
+        void enqueueUrlStats(UrlStatEntry stats) noexcept;
         /// @brief Worker loop that aggregates URL statistics.
         void addUrlStatsWorker();
         /// @brief Stops the aggregation worker.
@@ -206,7 +221,7 @@ namespace pinpoint {
         // Queue for incoming URL stats
         std::mutex add_mutex_{};
         std::condition_variable add_cond_var_{};
-        std::queue<std::unique_ptr<UrlStatEntry>> url_stats_{};
+        std::queue<UrlStatEntry> url_stats_{};
 
         // Snapshot management
         TickClock tick_clock_;

--- a/test/mock_agent_service.h
+++ b/test/mock_agent_service.h
@@ -63,13 +63,11 @@ public:
         recorded_spans_.push_back(std::move(span));
     }
 
-    void recordUrlStat(std::unique_ptr<UrlStatEntry> stat) const override {
+    void recordUrlStat(UrlStatEntry stat) const override {
         recorded_url_stats_++;
-        if (stat) {
-            last_url_stat_url_ = stat->url_pattern_;
-            last_url_stat_method_ = stat->method_;
-            last_url_stat_status_code_ = stat->status_code_;
-        }
+        last_url_stat_url_ = stat.url_pattern_;
+        last_url_stat_method_ = stat.method_;
+        last_url_stat_status_code_ = stat.status_code_;
     }
 
     void recordException(SpanData* span_data) const override {


### PR DESCRIPTION
## Summary
- Store URL stat entries by value through the span/agent queue path to avoid per-request UrlStatEntry heap allocation
- Batch-drain the URL stat queue and aggregate each batch under a single snapshot lock
- Switch URL stat snapshot aggregation from std::map to std::unordered_map and reduce URL trim/method-prefix string churn

## Verification
- cmake --preset vcpkg
- cmake --build build/vcpkg
- ctest --test-dir build/vcpkg --output-on-failure (20/20 passed)