### PR TITLE
[#noissue] Optimize span event chunk ordering

### DIFF
--- a/src/span.cpp
+++ b/src/span.cpp
@@ -76,22 +76,53 @@ namespace pinpoint {
         // NewSpanEvent calls would otherwise read the same pre-increment values
         // and emit duplicate sequence numbers, corrupting the server-side call
         // tree. The event takes the current counter value, then we advance it.
-        se->setSequence(event_sequence_.load());
-        se->setDepth(event_depth_.load());
+        se->setSequence(event_sequence_.fetch_add(1, std::memory_order_relaxed));
+        se->setDepth(event_depth_.fetch_add(1, std::memory_order_relaxed));
         event_stack_.push(se);
-        event_sequence_.fetch_add(1);
-        event_depth_.fetch_add(1);
     }
 
     void SpanData::finishSpanEvent() {
         std::unique_lock<std::mutex> lock(span_event_lock_);
-        const auto se = event_stack_.pop();
+        auto se = event_stack_.pop();
         if (se) {
             se->finish();
-            finished_events.push_back(se);
+            storeFinishedEvent(std::move(se));
         } else {
             LOG_WARN("finishSpanEvent: abnormal span - has no event");
         }
+    }
+
+    void SpanData::storeFinishedEvent(std::shared_ptr<SpanEventImpl> se) {
+        const auto sequence = se->getSequence();
+        if (finished_events.empty() || finished_events.back()->getSequence() < sequence) {
+            finished_events.emplace_back(std::move(se));
+            return;
+        }
+        if (sequence < finished_events.front()->getSequence()) {
+            finished_events.emplace_front(std::move(se));
+            return;
+        }
+
+        auto pos = std::lower_bound(
+            finished_events.begin(), finished_events.end(), sequence,
+            [](const std::shared_ptr<SpanEventImpl>& event, int32_t sequence) {
+                return event->getSequence() < sequence;
+            });
+        finished_events.insert(pos, std::move(se));
+    }
+
+    void SpanData::takeFinishedEvents(std::vector<std::shared_ptr<SpanEventImpl>>& out) {
+        std::unique_lock<std::mutex> lock(span_event_lock_);
+        out.clear();
+        if (finished_events.empty()) {
+            return;
+        }
+
+        out.reserve(finished_events.size());
+        for (auto& event : finished_events) {
+            out.emplace_back(std::move(event));
+        }
+        finished_events.clear();
     }
 
     void SpanData::parseTraceId(std::string &txid) noexcept {
@@ -157,18 +188,15 @@ namespace pinpoint {
 
     SpanChunk::SpanChunk(const std::shared_ptr<SpanData>& span_data, const bool final) :
                          span_data_(span_data),
-                         event_chunk_(span_data_->takeFinishedEvents()),
+                         event_chunk_{},
                          final_(final), key_time_(0) {
+        span_data_->takeFinishedEvents(event_chunk_);
     }
 
     void SpanChunk::optimizeSpanEvents() {
         if (event_chunk_.empty()) {
             return;
         }
-
-        std::sort(event_chunk_.begin(), event_chunk_.end(),
-            [](const std::shared_ptr<SpanEventImpl>& a, const std::shared_ptr<SpanEventImpl>& b)
-                  { return a->getSequence() < b->getSequence(); });
 
         int64_t prev_start_time = 0;
         int32_t prev_depth = 0;
@@ -240,10 +268,7 @@ namespace pinpoint {
             return noopSpanEvent();
         }
 
-        std::weak_ptr<Span> parent_span_ref;
-        if (auto self = weak_from_this().lock()) {
-            parent_span_ref = std::static_pointer_cast<Span>(self);
-        }
+        std::weak_ptr<Span> parent_span_ref = weak_from_this();
 
         auto se = std::make_shared<SpanEventImpl>(data_, operation, parent_span_ref);
         se->SetServiceType(service_type);

--- a/src/span.h
+++ b/src/span.h
@@ -17,10 +17,12 @@
 #pragma once
 
 #include <atomic>
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <stack>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "agent_service.h"
@@ -69,7 +71,7 @@ namespace pinpoint {
             if (stack_.empty()) {
                 return nullptr;
             }
-            auto item = stack_.top();
+            auto item = std::move(stack_.top());
             stack_.pop();
             return item;
         }
@@ -192,17 +194,17 @@ namespace pinpoint {
         int getFlags() const { return flags_; }
 
         /// @brief Sets the event sequence counter.
-        void setEventSequence(int32_t event_sequence) { event_sequence_.store(event_sequence); }
+        void setEventSequence(int32_t event_sequence) { event_sequence_.store(event_sequence, std::memory_order_relaxed); }
         /// @brief Returns the event sequence counter.
-        int32_t getEventSequence() const { return event_sequence_.load(); }
+        int32_t getEventSequence() const { return event_sequence_.load(std::memory_order_relaxed); }
 
         /// @brief Sets the current event depth.
-        void setEventDepth(int32_t event_depth) { event_depth_.store(event_depth); }
+        void setEventDepth(int32_t event_depth) { event_depth_.store(event_depth, std::memory_order_relaxed); }
         /// @brief Returns the current event depth.
-        int32_t getEventDepth() const { return event_depth_.load(); }
+        int32_t getEventDepth() const { return event_depth_.load(std::memory_order_relaxed); }
 
         /// @brief Decrements the event depth counter.
-        void decrEventDepth() { event_depth_.fetch_sub(1); }
+        void decrEventDepth() { event_depth_.fetch_sub(1, std::memory_order_relaxed); }
 
         /// @brief Sets the error code associated with the span.
         void setErr(int err) { err_ = err; }
@@ -283,11 +285,14 @@ namespace pinpoint {
         /// @note Locks span_event_lock_: finished_events is written under it by
         ///       finishSpanEvent(), so the move must be serialized against
         ///       concurrent pushes (e.g. EndSpanEvent racing EndSpan).
+        void takeFinishedEvents(std::vector<std::shared_ptr<SpanEventImpl>>& out);
+        /// @brief Transfers ownership of finished span events to a new vector.
         std::vector<std::shared_ptr<SpanEventImpl>> takeFinishedEvents() {
-            std::unique_lock<std::mutex> lock(span_event_lock_);
-            return std::move(finished_events);
+            std::vector<std::shared_ptr<SpanEventImpl>> events;
+            takeFinishedEvents(events);
+            return events;
         }
-    	/// @brief Returns the number of finished span events.
+        /// @brief Returns the number of finished span events.
     	size_t getFinishedEventsCount() const {
     	    std::unique_lock<std::mutex> lock(span_event_lock_);
     	    return finished_events.size();
@@ -316,6 +321,8 @@ namespace pinpoint {
     	const std::shared_ptr<const Config>& getConfig() const { return config_; }
 
     private:
+        void storeFinishedEvent(std::shared_ptr<SpanEventImpl> se);
+
     	TraceId trace_id_;
     	int64_t span_id_;
 
@@ -355,7 +362,8 @@ namespace pinpoint {
     	int32_t async_sequence_;
 
     	EventStack event_stack_;
-        std::vector<std::shared_ptr<SpanEventImpl>> finished_events;
+        // Kept sequence-ordered as events finish so chunks do not need to sort.
+        std::deque<std::shared_ptr<SpanEventImpl>> finished_events;
     	// mutable so const accessors (getFinishedEventsCount) can lock it.
     	mutable std::mutex span_event_lock_;
 

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -333,7 +333,9 @@ TEST_F(SpanTest, SpanDataSpanEventManagementTest) {
 
     // Take finished events (moves them out, leaving the vector empty)
     auto taken = span_data->takeFinishedEvents();
-    EXPECT_EQ(taken.size(), 2) << "Should have taken 2 finished events";
+    ASSERT_EQ(taken.size(), 2) << "Should have taken 2 finished events";
+    EXPECT_EQ(taken[0], event1) << "Finished events should be returned in sequence order";
+    EXPECT_EQ(taken[1], event2) << "Finished events should be returned in sequence order";
     EXPECT_EQ(span_data->getFinishedEventsCount(), 0) << "Finished events should be cleared";
 }
 
@@ -1151,13 +1153,18 @@ TEST_F(SpanTest, SpanChunkOptimizeMultipleEventsTest) {
     SpanChunk chunk(span_data, true);
     EXPECT_EQ(chunk.getSpanEventChunk().size(), 3);
 
+    auto& events = chunk.getSpanEventChunk();
+    ASSERT_EQ(events.size(), 3);
+    EXPECT_EQ(events[0], event1) << "SpanData should drain finished events in sequence order";
+    EXPECT_EQ(events[1], event2) << "SpanData should drain finished events in sequence order";
+    EXPECT_EQ(events[2], event3) << "SpanData should drain finished events in sequence order";
+
     chunk.optimizeSpanEvents();
 
-    // After optimization, events should be sorted by sequence
-    auto& events = chunk.getSpanEventChunk();
+    // Finished events are already sequence-ordered before optimization.
     for (size_t i = 1; i < events.size(); i++) {
         EXPECT_GE(events[i]->getSequence(), events[i-1]->getSequence())
-            << "Events should be sorted by sequence after optimization";
+            << "Events should remain sorted by sequence after optimization";
     }
 
     // key_time should be set to span start time for final chunks


### PR DESCRIPTION
## Summary
- keep finished span events sequence-ordered as they are completed so chunk optimization no longer sorts every chunk
- move span event shared_ptrs through pop/drain paths to reduce refcount churn
- use relaxed fetch_add for span event sequence/depth counters and avoid locking a parent shared_ptr during span event creation

## Verification
- cmake --preset vcpkg
- cmake --build build/vcpkg
- ctest --test-dir build/vcpkg --output-on-failure (20/20 passed; one transient test_logging rotation failure passed on immediate full rerun)