### PR TITLE
[#noissue] Reduce throughput rate limiter contention

### DIFF
--- a/src/limiter.cpp
+++ b/src/limiter.cpp
@@ -15,24 +15,67 @@
  */
 
 #include "limiter.h"
-#include <mutex>
+#include <chrono>
 
 namespace pinpoint {
 
-    bool RateLimiter::allow() {
-        std::lock_guard<std::mutex> lock(mutex_);
-        
-        const uint64_t now = std::chrono::duration_cast<std::chrono::seconds>(
-                         std::chrono::steady_clock::now().time_since_epoch()).count();
+    RateLimiter::RateLimiter(uint64_t tps)
+        : token_(tps),
+          epoch_(epoch_state(current_second())),
+          bucket_(tps) {
+    }
 
-        if (auto passed = now - base_time_; passed > 0) {
-            base_time_ = now;
-            bucket_ = token_;
+    uint64_t RateLimiter::current_second() {
+        return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::seconds>(
+                         std::chrono::steady_clock::now().time_since_epoch()).count());
+    }
+
+    uint64_t RateLimiter::epoch_state(uint64_t second) {
+        return second << 1;
+    }
+
+    uint64_t RateLimiter::epoch_second(uint64_t state) {
+        return state >> 1;
+    }
+
+    bool RateLimiter::is_resetting(uint64_t state) {
+        return (state & kResetInProgress) != 0;
+    }
+
+    bool RateLimiter::allow() {
+        if (token_ == 0) {
+            return false;
         }
 
-        if (bucket_ > 0) {
-            --bucket_;
-            return true;
+        const auto now = current_second();
+        auto epoch = epoch_.load(std::memory_order_acquire);
+
+        for (;;) {
+            if (is_resetting(epoch)) {
+                epoch = epoch_.load(std::memory_order_acquire);
+                continue;
+            }
+
+            if (now <= epoch_second(epoch)) {
+                break;
+            }
+
+            if (epoch_.compare_exchange_weak(epoch, epoch | kResetInProgress,
+                                             std::memory_order_acq_rel,
+                                             std::memory_order_acquire)) {
+                bucket_.store(token_, std::memory_order_relaxed);
+                epoch_.store(epoch_state(now), std::memory_order_release);
+                break;
+            }
+        }
+
+        auto bucket = bucket_.load(std::memory_order_relaxed);
+        while (bucket > 0) {
+            if (bucket_.compare_exchange_weak(bucket, bucket - 1,
+                                             std::memory_order_relaxed,
+                                             std::memory_order_relaxed)) {
+                return true;
+            }
         }
 
         return false;

--- a/src/limiter.h
+++ b/src/limiter.h
@@ -17,33 +17,34 @@
 #pragma once
 
 #include <atomic>
-#include <chrono>
-#include <mutex>
+#include <cstdint>
 
 namespace pinpoint {
 
     /**
-     * @brief Simple token-bucket rate limiter used for sampling throughput limits.
+     * @brief Fixed-window rate limiter used for sampling throughput limits.
      */
     class RateLimiter {
     public:
-        explicit RateLimiter(const uint64_t tps) {
-            token_ = bucket_ = tps;
-            base_time_ = std::chrono::duration_cast<std::chrono::seconds>(
-                     std::chrono::steady_clock::now().time_since_epoch()).count();
-        }
+        explicit RateLimiter(uint64_t tps);
 
         /**
-         * @brief Consumes a token if available, replenishing tokens based on elapsed time.
+         * @brief Consumes a token if available, resetting the bucket once per second.
          *
          * @return `true` when the call is permitted.
          */
         bool allow();
 
     private:
-        std::mutex mutex_;
-        uint64_t token_ = 0;
-        uint64_t base_time_ = 0;
-        uint64_t bucket_ = 0;
+        static constexpr uint64_t kResetInProgress = 1;
+
+        static uint64_t current_second();
+        static uint64_t epoch_state(uint64_t second);
+        static uint64_t epoch_second(uint64_t state);
+        static bool is_resetting(uint64_t state);
+
+        const uint64_t token_;
+        std::atomic<uint64_t> epoch_;
+        std::atomic<uint64_t> bucket_;
     };
 }


### PR DESCRIPTION
## Summary
- Replace the mutex-protected throughput RateLimiter path with atomic epoch reset and bucket CAS updates.
- Preserve per-second reset, no token accumulation, and thread-safe token consumption semantics.

## Verification
- cmake --preset vcpkg
- cmake --build build/vcpkg
- ctest --test-dir build/vcpkg --output-on-failure (20/20 passed)