### PR TITLE
[#noissue] Reduce API cache key allocation

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -15,7 +15,6 @@
  */
 
 #include <string>
-#include <charconv>
 #include <exception>
 #include <iterator>
 #include <utility>
@@ -35,21 +34,6 @@ namespace pinpoint {
 
     // Global agent singleton with thread-safe access
     namespace {
-        // Builds the API cache key "<api_str>_<api_type>". Uses std::to_chars
-        // into a stack buffer instead of std::to_string so the hot path (every
-        // span and span-event creation) does not allocate a throwaway string for
-        // the numeric suffix.
-        std::string build_api_cache_key(std::string_view api_str, int32_t api_type) {
-            char num[12];  // widest int32_t is 11 chars incl. sign
-            const auto res = std::to_chars(num, num + sizeof(num), api_type);
-            std::string key;
-            key.reserve(api_str.size() + 1 + static_cast<size_t>(res.ptr - num));
-            key.append(api_str);
-            key.push_back('_');
-            key.append(num, res.ptr);
-            return key;
-        }
-
         std::mutex global_agent_mutex;
 
         // The holder is intentionally heap-allocated and never destroyed so
@@ -93,7 +77,7 @@ namespace pinpoint {
         agent_stats_ = std::make_unique<AgentStats>(this);
         url_stats_ = std::make_unique<UrlStats>(this);
 
-        api_cache_ = std::make_unique<IdCache>(kCacheSize);
+        api_cache_ = std::make_unique<ApiIdCache>(kCacheSize);
         error_cache_ = std::make_unique<IdCache>(kCacheSize);
         sql_cache_ = std::make_unique<IdCache>(kCacheSize);
         sql_uid_cache_ = std::make_unique<SqlUidCache>(kCacheSize);
@@ -521,9 +505,7 @@ namespace pinpoint {
             return 0;
         }
 
-        const auto key = build_api_cache_key(api_str, api_type);
-
-        const auto [id, found] = api_cache_->get(key);
+        const auto [id, found] = api_cache_->get(ApiCacheKey{api_str, api_type});
         if (found) {
             return id;
         }
@@ -542,8 +524,7 @@ namespace pinpoint {
 
     void AgentImpl::removeCacheApi(const ApiMeta& api_meta) const {
         if (enabled_) {
-            const auto key = build_api_cache_key(api_meta.api_str_, api_meta.type_);
-            api_cache_->remove(key);
+            api_cache_->remove(ApiCacheKey{api_meta.api_str_, api_meta.type_});
         }
     }
 

--- a/src/agent.h
+++ b/src/agent.h
@@ -141,7 +141,7 @@ namespace pinpoint {
     	std::string agent_name_;
     	std::string service_name_;
 
-    	std::unique_ptr<IdCache> api_cache_{};
+		std::unique_ptr<ApiIdCache> api_cache_{};
     	std::unique_ptr<IdCache> error_cache_{};
     	std::unique_ptr<IdCache> sql_cache_{};
     	std::unique_ptr<SqlUidCache> sql_uid_cache_{};
@@ -150,7 +150,7 @@ namespace pinpoint {
     	std::unique_ptr<GrpcMetadata> grpc_metadata_{};
     	std::unique_ptr<GrpcSpan> grpc_span_{};
     	std::unique_ptr<GrpcStats> grpc_stat_{};
-	std::unique_ptr<GrpcCommand> grpc_command_{};
+		std::unique_ptr<GrpcCommand> grpc_command_{};
     	std::unique_ptr<UrlStats> url_stats_{};
     	std::unique_ptr<AgentStats> agent_stats_{};
 
@@ -159,7 +159,7 @@ namespace pinpoint {
     	std::thread meta_thread_;
     	std::thread span_thread_;
     	std::thread stat_thread_;
-	std::thread command_thread_;
+		std::thread command_thread_;
     	std::thread url_stat_add_thread_;
     	std::thread url_stat_send_thread_;
     	std::thread agent_stat_thread_;

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -19,13 +19,6 @@
 
 namespace pinpoint {
 
-    CacheResult IdCache::get(std::string_view key) {
-        // Use the template cache with a lambda generator for new IDs
-        return cache_.get(key, [this]() {
-            return ++id_sequence_;
-        });
-    }
-
     SqlUidCacheResult SqlUidCache::get(std::string_view key) {
         // Use the template cache with a lambda generator for new UIDs
         return cache_.get(key, [&key]() {

--- a/src/cache.h
+++ b/src/cache.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <list>
 #include <mutex>
 #include <shared_mutex>
@@ -49,6 +50,70 @@ namespace pinpoint {
      */
     using CacheResult = LruCacheResult<int32_t>;
 
+    struct ApiCacheKey {
+        std::string_view api_str;
+        int32_t api_type;
+    };
+
+    struct ApiCacheStoredKey {
+        std::string api_str;
+        int32_t api_type;
+    };
+
+    struct ApiCacheKeyHash {
+        size_t operator()(const ApiCacheKey& key) const noexcept {
+            size_t seed = std::hash<std::string_view>{}(key.api_str);
+            seed ^= std::hash<int32_t>{}(key.api_type) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            return seed;
+        }
+    };
+
+    struct ApiCacheKeyEqual {
+        bool operator()(const ApiCacheKey& lhs, const ApiCacheKey& rhs) const noexcept {
+            return lhs.api_type == rhs.api_type && lhs.api_str == rhs.api_str;
+        }
+    };
+
+    struct StringCacheKeyTraits {
+        using LookupKey = std::string_view;
+        using StoredKey = std::string;
+        using MapKey = std::string_view;
+        using Hash = std::hash<MapKey>;
+        using Equal = std::equal_to<MapKey>;
+
+        static MapKey lookup_key(LookupKey key) noexcept {
+            return key;
+        }
+
+        static StoredKey store(LookupKey key) {
+            return std::string(key);
+        }
+
+        static MapKey map_key(const StoredKey& key) noexcept {
+            return std::string_view(key);
+        }
+    };
+
+    struct ApiCacheKeyTraits {
+        using LookupKey = ApiCacheKey;
+        using StoredKey = ApiCacheStoredKey;
+        using MapKey = ApiCacheKey;
+        using Hash = ApiCacheKeyHash;
+        using Equal = ApiCacheKeyEqual;
+
+        static MapKey lookup_key(LookupKey key) noexcept {
+            return key;
+        }
+
+        static StoredKey store(LookupKey key) {
+            return ApiCacheStoredKey{std::string(key.api_str), key.api_type};
+        }
+
+        static MapKey map_key(const StoredKey& key) noexcept {
+            return ApiCacheKey{key.api_str, key.api_type};
+        }
+    };
+
     /**
      * @brief Result returned from `SqlUidCache::get`.
      *
@@ -62,17 +127,20 @@ namespace pinpoint {
      * @brief Thread-safe LRU cache implementation template.
      *
      * Combines a std::list (LRU ordering) with a std::unordered_map keyed by
-     * std::string_view (O(1) lookup, no std::string allocation on the hit path).
+     * a non-owning map key from KeyTraits (O(1) lookup, no allocation on the hit path).
      * Access is guarded by a std::shared_mutex: lookups take a shared lock so
      * cache hits run concurrently. LRU reordering is performed lazily — only once
      * the cache has reached max_size — because no eviction can occur before then,
      * which makes the ordering irrelevant while the cache is still filling up.
      *
      * @tparam ValueType Type of values stored in the cache.
+     * @tparam KeyTraits Converts lookup keys into owned storage and map keys.
      */
-    template<typename ValueType>
+    template<typename ValueType, typename KeyTraits = StringCacheKeyTraits>
     class LruCacheImpl {
     public:
+        using LookupKey = typename KeyTraits::LookupKey;
+
         explicit LruCacheImpl(size_t max_size) : max_size_(max_size) {
             // Reserve buckets up front so the map never rehashes while warming
             // up to capacity. +1 covers the transient over-capacity entry that
@@ -97,17 +165,18 @@ namespace pinpoint {
          * in once the cache is full. On a miss the generator runs OUTSIDE any lock,
          * so an expensive generator does not serialize other threads' lookups.
          *
-         * @param key The key to look up (string_view — no allocation on hit).
+         * @param key The key to look up (no allocation on hit).
          * @param generator Function to generate a new value if key not found.
          * @return Result containing the value and whether it was found.
          */
         template<typename Generator>
-        LruCacheResult<ValueType> get(std::string_view key, Generator&& generator) {
+        LruCacheResult<ValueType> get(LookupKey key, Generator&& generator) {
+            const auto map_key = KeyTraits::lookup_key(key);
             bool hit_while_full = false;
             {
                 // Fast path: a shared lock lets concurrent hits proceed in parallel.
                 std::shared_lock<std::shared_mutex> lock(mutex_);
-                const auto it = cache_map_.find(key);
+                const auto it = cache_map_.find(map_key);
                 if (it != cache_map_.end()) {
                     if (cache_map_.size() < max_size_) {
                         // Below capacity: nothing can be evicted, so LRU order does
@@ -125,7 +194,7 @@ namespace pinpoint {
                 // the two locks, so re-resolve; if it is gone, fall through to
                 // regenerate it below.
                 std::unique_lock<std::shared_mutex> lock(mutex_);
-                const auto it = cache_map_.find(key);
+                const auto it = cache_map_.find(map_key);
                 if (it != cache_map_.end()) {
                     cache_list_.splice(cache_list_.begin(), cache_list_, it->second);
                     return LruCacheResult<ValueType>{it->second->second, true};
@@ -146,10 +215,10 @@ namespace pinpoint {
          *
          * @param key The key to remove.
          */
-        void remove(std::string_view key) {
+        void remove(LookupKey key) {
             std::unique_lock<std::shared_mutex> lock(mutex_);
 
-            const auto it = cache_map_.find(key);
+            const auto it = cache_map_.find(KeyTraits::lookup_key(key));
             if (it != cache_map_.end()) {
                 cache_list_.erase(it->second);
                 cache_map_.erase(it);
@@ -171,15 +240,15 @@ namespace pinpoint {
          * @param key The key to insert (copied into storage only when inserting).
          * @param value The freshly generated value (moved).
          */
-        LruCacheResult<ValueType> insert_or_promote(std::string_view key, ValueType&& value) {
+        LruCacheResult<ValueType> insert_or_promote(LookupKey key, ValueType&& value) {
             // Speculatively create the list node first so the map key can be a
-            // string_view into the node's owned string (single key allocation).
-            cache_list_.emplace_front(std::string(key), std::move(value));
+            // view into the node's owned key storage (single key allocation).
+            cache_list_.emplace_front(KeyTraits::store(key), std::move(value));
             const auto list_it = cache_list_.begin();
 
             std::pair<typename MapType::iterator, bool> inserted;
             try {
-                inserted = cache_map_.try_emplace(std::string_view(list_it->first), list_it);
+                inserted = cache_map_.try_emplace(KeyTraits::map_key(list_it->first), list_it);
             } catch (...) {
                 cache_list_.pop_front();  // Rollback the speculative node
                 throw;
@@ -195,14 +264,17 @@ namespace pinpoint {
 
             // Evict least recently used entry if over capacity
             if (cache_map_.size() > max_size_) {
-                cache_map_.erase(std::string_view(cache_list_.back().first));
+                cache_map_.erase(KeyTraits::map_key(cache_list_.back().first));
                 cache_list_.pop_back();
             }
             return LruCacheResult<ValueType>{list_it->second, false};
         }
 
-        using KeyValuePair = std::pair<std::string, ValueType>;
-        using MapType = std::unordered_map<std::string_view, typename std::list<KeyValuePair>::iterator>;
+        using KeyValuePair = std::pair<typename KeyTraits::StoredKey, ValueType>;
+        using MapType = std::unordered_map<typename KeyTraits::MapKey,
+                                          typename std::list<KeyValuePair>::iterator,
+                                          typename KeyTraits::Hash,
+                                          typename KeyTraits::Equal>;
         std::list<KeyValuePair> cache_list_{};
         MapType cache_map_{};
         const size_t max_size_{};
@@ -210,43 +282,53 @@ namespace pinpoint {
     };
 
     /**
-     * @brief LRU cache that assigns numeric identifiers to frequently used strings.
+     * @brief LRU cache that assigns numeric identifiers to frequently used keys.
      *
-     * The cache is used for API and error metadata to minimize payload sizes when
-     * sending data over gRPC.
+     * The cache is used for API, SQL, and error metadata to minimize payload sizes
+     * when sending data over gRPC.
      */
-    class IdCache {
+    template<typename KeyTraits = StringCacheKeyTraits>
+    class IdCacheImpl {
     public:
-        explicit IdCache(size_t max_size) : cache_(max_size) {}
-        ~IdCache() = default;
+        using LookupKey = typename KeyTraits::LookupKey;
+
+        explicit IdCacheImpl(size_t max_size) : cache_(max_size) {}
+        ~IdCacheImpl() = default;
 
         // Delete copy and move operations
-        IdCache(const IdCache&) = delete;
-        IdCache& operator=(const IdCache&) = delete;
-        IdCache(IdCache&&) = delete;
-        IdCache& operator=(IdCache&&) = delete;
+        IdCacheImpl(const IdCacheImpl&) = delete;
+        IdCacheImpl& operator=(const IdCacheImpl&) = delete;
+        IdCacheImpl(IdCacheImpl&&) = delete;
+        IdCacheImpl& operator=(IdCacheImpl&&) = delete;
 
         /**
-         * @brief Looks up or inserts a string identifier.
+         * @brief Looks up or inserts a key identifier.
          *
-         * @param key String to cache (no allocation on cache hit).
+         * @param key Key to cache (no allocation on cache hit).
          * @return CacheResult containing the identifier and whether the entry already existed.
          */
-        CacheResult get(std::string_view key);
+        CacheResult get(LookupKey key) {
+            return cache_.get(key, [this]() {
+                return ++id_sequence_;
+            });
+        }
 
         /**
-         * @brief Evicts a cached string from the cache.
+         * @brief Evicts a cached key from the cache.
          *
          * @param key Entry to remove.
          */
-        void remove(std::string_view key) {
+        void remove(LookupKey key) {
             cache_.remove(key);
         }
 
     private:
-        LruCacheImpl<int32_t> cache_;
+        LruCacheImpl<int32_t, KeyTraits> cache_;
         std::atomic<int32_t> id_sequence_{0};
     };
+
+    using IdCache = IdCacheImpl<StringCacheKeyTraits>;
+    using ApiIdCache = IdCacheImpl<ApiCacheKeyTraits>;
 
     /**
      * @brief LRU cache that assigns binary UIDs to normalized SQL statements.

--- a/test/test_agent_with_mocks.cpp
+++ b/test/test_agent_with_mocks.cpp
@@ -278,6 +278,12 @@ TEST_F(AgentImplTest, CacheApiReturnsDifferentIdForDifferentKeys) {
     EXPECT_NE(id1, id2);
 }
 
+TEST_F(AgentImplTest, CacheApiReturnsDifferentIdForDifferentTypes) {
+    int32_t id1 = agent_->cacheApi("com.example.Api", 100);
+    int32_t id2 = agent_->cacheApi("com.example.Api", 200);
+    EXPECT_NE(id1, id2);
+}
+
 TEST_F(AgentImplTest, CacheErrorReturnsNonZeroId) {
     int32_t id = agent_->cacheError("TestError");
     EXPECT_NE(id, 0);

--- a/test/test_cache.cpp
+++ b/test/test_cache.cpp
@@ -580,6 +580,65 @@ TEST_F(CacheTest, SpecialCharacterKeysTest) {
     EXPECT_TRUE(cache.get(null_key).found);
 }
 
+// API cache tests
+
+TEST_F(CacheTest, ApiIdCacheKeepsTypesDistinctTest) {
+    ApiIdCache cache(5);
+
+    auto result1 = cache.get(ApiCacheKey{"operation", 100});
+    auto result2 = cache.get(ApiCacheKey{"operation", 200});
+
+    EXPECT_FALSE(result1.found);
+    EXPECT_FALSE(result2.found);
+    EXPECT_NE(result1.value, result2.value) << "Same API string with different types should be distinct";
+
+    auto result1_again = cache.get(ApiCacheKey{"operation", 100});
+    EXPECT_EQ(result1_again.value, result1.value);
+    EXPECT_TRUE(result1_again.found);
+}
+
+TEST_F(CacheTest, ApiIdCacheRemoveOnlyMatchingTypeTest) {
+    ApiIdCache cache(5);
+
+    auto result1 = cache.get(ApiCacheKey{"operation", 100});
+    auto result2 = cache.get(ApiCacheKey{"operation", 200});
+
+    cache.remove(ApiCacheKey{"operation", 100});
+
+    auto removed = cache.get(ApiCacheKey{"operation", 100});
+    EXPECT_FALSE(removed.found);
+    EXPECT_NE(removed.value, result1.value);
+
+    auto retained = cache.get(ApiCacheKey{"operation", 200});
+    EXPECT_TRUE(retained.found);
+    EXPECT_EQ(retained.value, result2.value);
+}
+
+TEST_F(CacheTest, ApiIdCacheStringViewKeyFromTemporaryTest) {
+    ApiIdCache cache(5);
+
+    {
+        std::string temp_key = "temporary_operation";
+        cache.get(ApiCacheKey{temp_key, 100});
+    }
+
+    auto result = cache.get(ApiCacheKey{"temporary_operation", 100});
+    EXPECT_EQ(result.value, 1);
+    EXPECT_TRUE(result.found);
+}
+
+TEST_F(CacheTest, ApiIdCacheLRUEvictionTest) {
+    ApiIdCache cache(2);
+
+    cache.get(ApiCacheKey{"operation1", 100});
+    cache.get(ApiCacheKey{"operation2", 100});
+    cache.get(ApiCacheKey{"operation1", 100});
+    cache.get(ApiCacheKey{"operation3", 100});
+
+    EXPECT_TRUE(cache.get(ApiCacheKey{"operation1", 100}).found);
+    EXPECT_FALSE(cache.get(ApiCacheKey{"operation2", 100}).found);
+}
+
 // SqlUidCache Test Suite
 class SqlUidCacheTest : public ::testing::Test {
 protected:


### PR DESCRIPTION
Summary:
- Generalize LruCacheImpl with key traits so string_view and ApiCacheKey share the same LRU implementation.
- Use ApiCacheKey for API metadata lookups to avoid building <api_str>_<api_type> strings on cache hits.
- Keep metadata enqueue, retry removal, and cache behavior covered by tests.

Tests:
- cmake --build build/vcpkg
- ctest --test-dir build/vcpkg --output-on-failure (20/20 passed)