### PR TITLE
[#noissue] Never detach in abandon_thread: glibc segfaults on fork-dead handles

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -454,9 +454,10 @@ namespace pinpoint {
         LOG_INFO("close grpc workers done");
     }
 
-    void AgentImpl::detach_grpc_workers() noexcept {
-        // Abandon (never join) every worker handle, including handles inherited
-        // across fork() on which detach() would throw — see abandon_thread().
+    void AgentImpl::abandon_grpc_workers() noexcept {
+        // Abandon (never join or detach) every worker handle, including
+        // handles inherited across fork(), on which even pthread_detach is
+        // unsafe — see abandon_thread().
         abandon_thread(init_thread_);
         abandon_thread(ping_thread_);
         abandon_thread(meta_thread_);
@@ -539,7 +540,7 @@ namespace pinpoint {
         }
 
         if (!finished) {
-            // Do NOT detach: the workers still reference `this` and the gRPC
+            // Do NOT abandon them: the workers still reference `this` and the gRPC
             // client members, which ~AgentImpl is about to destroy. Keep
             // waiting — their blocking points are bounded, so this returns
             // shortly; we only note that shutdown ran long.
@@ -553,10 +554,10 @@ namespace pinpoint {
 
         // Belt-and-braces: if do_shutdown() bailed out early for any reason,
         // a joinable std::thread member would call std::terminate() when its
-        // destructor runs. Detach any stragglers so member destruction stays
-        // benign. Detach (not join) is used because by this point the
+        // destructor runs. Abandon any stragglers so member destruction stays
+        // benign. Abandon (not join) is used because by this point the
         // process is likely on its way down and we don't want to block.
-        detach_grpc_workers();
+        abandon_grpc_workers();
     }
 
 	SpanPtr AgentImpl::NewSpan(std::string_view operation, std::string_view rpc_point) {
@@ -664,10 +665,10 @@ namespace pinpoint {
         // torn down in a forked child (owner_pid_ != getpid()), its worker and
         // watcher threads and its gRPC runtime do not exist in this process.
         // Joining those dead handles would abort; touching the inherited gRPC
-        // stack is unsafe. Detach the handles and skip the normal teardown.
+        // stack is unsafe. Abandon the handles and skip the normal teardown.
         if (owner_pid_ != 0 && owner_pid_ != getpid()) {
-            try { LOG_INFO("agent shutdown in forked child: detaching inherited workers"); } catch (...) {}
-            detach_grpc_workers();
+            try { LOG_INFO("agent shutdown in forked child: abandoning inherited workers"); } catch (...) {}
+            abandon_grpc_workers();
             // The gRPC clients own their own internal threads (e.g. GrpcAgent's
             // AgentInfo scheduler, the command dispatcher) that were started in
             // the parent; their destructors would join those now-dead handles

--- a/src/agent.h
+++ b/src/agent.h
@@ -213,9 +213,9 @@ namespace pinpoint {
     	std::atomic<bool> enabled_{false};
     	std::atomic<bool> shutting_down_{false};
     	// Fork-safe lifecycle. Start() flips started_ and records owner_pid_ (the
-    	// pid that actually brought the agent online); teardown detaches instead
-    	// of joins when it runs in a different process (a forked child inheriting
-    	// dead thread handles). create_pid_ is the pid that constructed the agent
+    	// pid that actually brought the agent online); teardown abandons the
+    	// handles instead of joining when it runs in a different process (a
+    	// forked child inheriting dead thread handles). create_pid_ is the pid that constructed the agent
     	// (CreateAgent time); Start() compares against it to detect that it is
     	// running in a forked child and must give this worker a unique agent id.
     	std::atomic<bool> started_{false};
@@ -244,10 +244,11 @@ namespace pinpoint {
     	/// the process that constructed the agent, so non-fork behavior is
     	/// unchanged.
     	void refresh_agent_id_for_process();
-    	/// @brief Detaches (never joins) every worker thread handle. Used when
-    	/// tearing down an agent inherited across fork(), where the handles are
-    	/// joinable but reference threads that do not exist in this process.
-    	void detach_grpc_workers() noexcept;
+    	/// @brief Abandons (never joins or detaches — see abandon_thread())
+    	/// every worker thread handle. Used when tearing down an agent inherited
+    	/// across fork(), where the handles are joinable but reference threads
+    	/// that do not exist in this process.
+    	void abandon_grpc_workers() noexcept;
     	/// @brief Signals all gRPC workers to stop and joins their threads.
     	void close_grpc_workers();
     	/// @brief Waits for all gRPC workers to finish execution.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -164,8 +164,8 @@ namespace pinpoint {
 
     // pid that started the watcher thread. After a fork() the child inherits a
     // joinable-but-dead watcher handle whose pid no longer matches; joining it
-    // would fail and terminate the process, so start/stop below detach such an
-    // inherited handle instead of joining it.
+    // would fail and terminate the process, so start/stop below abandon such
+    // an inherited handle instead of joining it.
     static pid_t& config_watcher_owner_pid() {
         static pid_t pid = 0;
         return pid;
@@ -201,8 +201,8 @@ namespace pinpoint {
             // A joinable handle from THIS process means the watcher is already
             // running. A joinable handle inherited across fork() references a
             // thread that does not exist in this child — abandon it (never
-            // join; plain detach() throws ESRCH on such a handle) and fall
-            // through to start a fresh watcher for this process.
+            // join or detach; see abandon_thread()) and fall through to start
+            // a fresh watcher for this process.
             if (config_watcher_owner_pid() == getpid()) {
                 return;
             }
@@ -265,7 +265,8 @@ namespace pinpoint {
             }
             // Inherited across fork(): the thread does not exist here, so
             // abandon the dead handle rather than joining it (which would
-            // abort). Plain detach() throws ESRCH on such a handle.
+            // abort) or detaching it (which segfaults on glibc — see
+            // abandon_thread()).
             if (config_watcher_owner_pid() != getpid()) {
                 abandon_thread(watcher);
                 return;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -114,11 +114,14 @@ namespace pinpoint {
         if (!t.joinable()) {
             return;
         }
-        try {
-            t.detach();
-        } catch (...) {
-            try { new std::thread(std::move(t)); } catch (...) {}
-        }
+        // Never detach(): for a handle inherited across fork(), glibc's
+        // pthread_detach unconditionally dereferences the thread descriptor,
+        // which the child's fork() has already reclaimed (__reclaim_stacks) —
+        // it segfaults instead of returning ESRCH as macOS does. The leak-move
+        // makes no pthread call at all: it only transfers the handle into a
+        // heap std::thread that is intentionally never destroyed, leaving t
+        // non-joinable.
+        try { new std::thread(std::move(t)); } catch (...) {}
     }
 
     bool compare_string(std::string_view str1, std::string_view str2) {

--- a/src/utility.h
+++ b/src/utility.h
@@ -64,17 +64,20 @@ namespace pinpoint {
     std::optional<bool> stob_(std::string_view str);
 
     /**
-     * @brief Abandons a thread handle without ever joining it, tolerating
-     *        handles inherited across fork().
+     * @brief Abandons a thread handle without joining or detaching it,
+     *        tolerating handles inherited across fork().
      *
-     * For a live thread detach() succeeds and clears the handle. For a handle
-     * inherited across fork(), the underlying thread does not exist in the
-     * child, so pthread_detach returns ESRCH and std::thread::detach() THROWS —
-     * leaving the handle still joinable. Letting such a handle reach
-     * ~std::thread would call std::terminate(). So on detach failure, the dead
-     * handle is moved into a heap std::thread that is intentionally never
-     * destroyed: the move leaves @p t non-joinable (its destructor becomes a
-     * no-op) and nothing ever joins/destroys the leaked handle.
+     * The joinable handle is leak-moved into a heap std::thread that is
+     * intentionally never destroyed: the move leaves @p t non-joinable (its
+     * destructor becomes a no-op), nothing ever joins or destroys the leaked
+     * handle, and no pthread call is made on it. detach() must never be used
+     * here: for a handle inherited across fork() the thread does not exist in
+     * the child, and while macOS pthread_detach fails cleanly with ESRCH
+     * (making std::thread::detach() throw catchably), glibc unconditionally
+     * dereferences the thread descriptor — memory the child's fork() has
+     * already reclaimed — and crashes. Cost of the leak: a LIVE abandoned
+     * thread keeps its stack until process exit instead of releasing it at
+     * thread exit; a fork-dead handle leaks only the handle itself.
      */
     void abandon_thread(std::thread& t) noexcept;
 

--- a/test/test_fork.cpp
+++ b/test/test_fork.cpp
@@ -205,7 +205,7 @@ TEST(ForkLifecycleTest, ChildStartYieldsWorkingAgentWithUniqueId) {
 
 // Safety net: an agent that was STARTED in the master is inherited by a child
 // and torn down there. The child's worker threads do not exist, so teardown
-// must detach (never join) — the child must not abort.
+// must abandon the handles (never join or detach) — the child must not abort.
 TEST(ForkLifecycleTest, TeardownOfInheritedStartedAgentDoesNotAbort) {
     auto cfg = make_fork_config();
     auto agent = make_cold_agent(cfg);


### PR DESCRIPTION
## Problem

`abandon_thread()` (src/utility.cpp) is the primitive behind the fork-safe teardown contract: a handle inherited across `fork()` must be neutralized without joining. It relied on `std::thread::detach()` failing cleanly for such a handle — `pthread_detach` returning `ESRCH`, `detach()` throwing, and the catch block leak-moving the handle.

That assumption only holds on macOS. On Linux glibc, `pthread_detach` never validates the handle: it unconditionally dereferences the `pthread_t` as a `struct pthread*`. After `fork()`, the child's glibc has already reclaimed other threads' stacks and descriptors (`__reclaim_stacks`), so the dereference crashes with SIGSEGV instead of returning `ESRCH`. Observed with gdb on aarch64 Ubuntu 24.04:

```
___pthread_detach
→ std::thread::detach
→ pinpoint::abandon_thread        (utility.cpp)
→ AgentImpl::detach_grpc_workers  (agent.cpp)
→ AgentImpl::do_shutdown          (owner_pid-guarded forked-child path)
→ Agent::Shutdown
```

This breaks the documented crash-free teardown of an agent started in the parent and torn down in a forked child (`ForkLifecycleTest.TeardownOfInheritedStartedAgentDoesNotAbort` documents the contract; it passes on macOS but the same path segfaults on Linux glibc). The config-file-watcher teardown (`config.cpp`) abandons inherited handles through the same primitive.

## Fix

Never call `detach()`. Unconditionally leak-move the joinable handle into a heap `std::thread` that is intentionally never destroyed:

```cpp
try { new std::thread(std::move(t)); } catch (...) {}
```

The move makes **no pthread call at all** and leaves the argument non-joinable, so `~std::thread` stays benign on every platform — the crash site is removed by construction, not worked around.

**Cost:** a *live* abandoned thread (e.g. a straggler at `~AgentImpl` after `do_shutdown()` bailed early) keeps its stack until process exit instead of releasing it at thread exit. That case is rare and bounded; the alternative on glibc is a segfault. Fork-dead handles leak only the handle itself, as before.

Also renames `detach_grpc_workers()` → `abandon_grpc_workers()` and updates the doc comment in `utility.h` plus the fork-safety comments in `agent.cpp`/`config.cpp` that repeated the ESRCH assumption.

## Verification

- Root cause captured with gdb on aarch64 Ubuntu 24.04 (stack above); the fix removes the offending call entirely.
- Full gtest suite passes on macOS, where the leak-move path — previously only the fallback — now runs unconditionally, including all `ForkLifecycleTest` cases.
- The pinpoint-python-agent build and test suite (which embeds this agent and exercises real fork scenarios against a live collector mock) passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
